### PR TITLE
feat(login): mirrorstack login command

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -19,7 +19,24 @@ const (
 	defaultWebBase = "https://account.mirrorstack.ai"
 )
 
-func runLogin(_ []string) error {
+func runLogin(args []string) error {
+	if len(args) > 0 {
+		switch args[0] {
+		case "help", "--help", "-h":
+			fmt.Println(`Usage:
+  mirrorstack login
+
+Sign in to MirrorStack via OAuth.
+
+Environment overrides (for local development):
+  MIRRORSTACK_API_URL    API base URL (default ` + defaultAPIBase + `)
+  MIRRORSTACK_WEB_URL    Web base URL (default = API)`)
+			return nil
+		default:
+			return fmt.Errorf("login: unexpected argument %q (run `mirrorstack login help`)", args[0])
+		}
+	}
+
 	apiBase := getenvOr("MIRRORSTACK_API_URL", defaultAPIBase)
 	// Web is co-located with the API service in production. Override
 	// independently when running against a split local dev setup.
@@ -82,9 +99,11 @@ func readLine(r *os.File) (string, error) {
 	s := bufio.NewScanner(r)
 	if !s.Scan() {
 		if err := s.Err(); err != nil {
-			return "", err
+			return "", fmt.Errorf("read input: %w", err)
 		}
-		return "", errors.New("input closed")
+		// Scan returned false with no error → EOF. Most common cause is
+		// a non-interactive shell (CI, script piping nothing). Hint at it.
+		return "", errors.New("read input: end of input (no code provided)")
 	}
 	return s.Text(), nil
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -15,7 +15,12 @@ import (
 )
 
 const (
-	defaultAPIBase = "https://account.mirrorstack.ai"
+	// defaultAPIBase is the api-platform service. Distinct from the web
+	// frontend at defaultWebBase — the CLI talks to the API directly.
+	defaultAPIBase = "https://api.mirrorstack.ai"
+	// defaultWebBase is the account.mirrorstack.ai consent page. The CLI
+	// only sends the user here to approve; it never POSTs against this
+	// host itself.
 	defaultWebBase = "https://account.mirrorstack.ai"
 )
 
@@ -30,7 +35,7 @@ Sign in to MirrorStack via OAuth.
 
 Environment overrides (for local development):
   MIRRORSTACK_API_URL    API base URL (default ` + defaultAPIBase + `)
-  MIRRORSTACK_WEB_URL    Web base URL (default = API)`)
+  MIRRORSTACK_WEB_URL    Web base URL (default ` + defaultWebBase + `)`)
 			return nil
 		default:
 			return fmt.Errorf("login: unexpected argument %q (run `mirrorstack login help`)", args[0])
@@ -41,9 +46,7 @@ Environment overrides (for local development):
 	if v := os.Getenv("MIRRORSTACK_API_URL"); v != "" {
 		apiBase = v
 	}
-	// Web is co-located with the API service in production. Override
-	// independently when running against a split local dev setup.
-	webBase := apiBase
+	webBase := defaultWebBase
 	if v := os.Getenv("MIRRORSTACK_WEB_URL"); v != "" {
 		webBase = v
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -37,10 +37,16 @@ Environment overrides (for local development):
 		}
 	}
 
-	apiBase := getenvOr("MIRRORSTACK_API_URL", defaultAPIBase)
+	apiBase := defaultAPIBase
+	if v := os.Getenv("MIRRORSTACK_API_URL"); v != "" {
+		apiBase = v
+	}
 	// Web is co-located with the API service in production. Override
 	// independently when running against a split local dev setup.
-	webBase := getenvOr("MIRRORSTACK_WEB_URL", apiBase)
+	webBase := apiBase
+	if v := os.Getenv("MIRRORSTACK_WEB_URL"); v != "" {
+		webBase = v
+	}
 
 	pkce, err := auth.NewPKCE()
 	if err != nil {
@@ -108,9 +114,3 @@ func readLine(r *os.File) (string, error) {
 	return s.Text(), nil
 }
 
-func getenvOr(key, fallback string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return fallback
-}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mirrorstack-ai/mirrorstack-cli/internal/auth"
+	"github.com/mirrorstack-ai/mirrorstack-cli/internal/browser"
+	"github.com/mirrorstack-ai/mirrorstack-cli/internal/credentials"
+)
+
+const (
+	defaultAPIBase = "https://account.mirrorstack.ai"
+	defaultWebBase = "https://account.mirrorstack.ai"
+)
+
+func runLogin(_ []string) error {
+	apiBase := getenvOr("MIRRORSTACK_API_URL", defaultAPIBase)
+	// Web is co-located with the API service in production. Override
+	// independently when running against a split local dev setup.
+	webBase := getenvOr("MIRRORSTACK_WEB_URL", apiBase)
+
+	pkce, err := auth.NewPKCE()
+	if err != nil {
+		return err
+	}
+	state, err := auth.NewState()
+	if err != nil {
+		return err
+	}
+
+	authorizeURL := auth.AuthorizeURL(webBase, state, pkce)
+
+	fmt.Println("Opening your browser to sign in:")
+	fmt.Println()
+	fmt.Println("  " + authorizeURL)
+	fmt.Println()
+	if err := browser.Open(authorizeURL); err != nil {
+		fmt.Fprintln(os.Stderr, "(could not auto-open browser; copy the URL above and paste it manually)")
+	}
+
+	fmt.Print("After approving in the browser, paste the code here: ")
+	code, err := readLine(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("login: read code: %w", err)
+	}
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return errors.New("login: no code entered")
+	}
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	tokens, err := auth.ExchangeCode(httpClient, apiBase, code, pkce)
+	if err != nil {
+		if errors.Is(err, auth.ErrInvalidGrant) {
+			return errors.New("login: code didn't work — it may have expired or already been used. Run `mirrorstack login` again to get a fresh one.")
+		}
+		return err
+	}
+
+	creds := credentials.Credentials{
+		AccessToken:  tokens.AccessToken,
+		RefreshToken: tokens.RefreshToken,
+		ExpiresAt:    time.Now().Add(time.Duration(tokens.ExpiresIn) * time.Second),
+	}
+	if err := credentials.Save(creds); err != nil {
+		return err
+	}
+
+	path, _ := credentials.Path()
+	fmt.Println()
+	fmt.Println("Signed in. Tokens saved to", path)
+	return nil
+}
+
+func readLine(r *os.File) (string, error) {
+	s := bufio.NewScanner(r)
+	if !s.Scan() {
+		if err := s.Err(); err != nil {
+			return "", err
+		}
+		return "", errors.New("input closed")
+	}
+	return s.Text(), nil
+}
+
+func getenvOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,8 @@ func Run(args []string) error {
 	switch args[0] {
 	case "app":
 		return runApp(args[1:])
+	case "login":
+		return runLogin(args[1:])
 	case "version", "--version", "-v":
 		fmt.Println("mirrorstack", version)
 		return nil
@@ -65,6 +67,7 @@ Usage:
   mirrorstack <command>
 
 Commands:
+  login       Sign in to MirrorStack
   app         App and module management
   version     Show CLI version
   help        Show this help`)

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -131,15 +131,19 @@ func ExchangeCode(httpClient *http.Client, apiBase, code string, p PKCE) (TokenR
 		return tr, nil
 	}
 
-	// Try to parse RFC 6749 §5.2 error body so we can map invalid_grant
-	// to ErrInvalidGrant.
+	// Parse RFC 6749 §5.2 error body and map known codes to typed
+	// sentinels so callers can branch (login command swaps in friendly
+	// messages; future commands may retry on transient server errors).
 	var errBody struct {
 		Error            string `json:"error"`
 		ErrorDescription string `json:"error_description"`
 	}
 	_ = json.Unmarshal(body, &errBody)
-	if errBody.Error == "invalid_grant" {
-		return TokenResponse{}, ErrInvalidGrant
+	if sentinel, ok := errSentinels[errBody.Error]; ok {
+		return TokenResponse{}, sentinel
+	}
+	if resp.StatusCode >= 500 {
+		return TokenResponse{}, fmt.Errorf("%w: %d %s", ErrServerError, resp.StatusCode, errBody.ErrorDescription)
 	}
 	if errBody.Error != "" {
 		return TokenResponse{}, fmt.Errorf("auth: %s: %s", errBody.Error, errBody.ErrorDescription)
@@ -147,10 +151,24 @@ func ExchangeCode(httpClient *http.Client, apiBase, code string, p PKCE) (TokenR
 	return TokenResponse{}, fmt.Errorf("auth: unexpected response %d: %s", resp.StatusCode, string(body))
 }
 
-// ErrInvalidGrant maps to the OAuth invalid_grant error. The login
-// command catches this to suggest re-running rather than dumping a
-// raw protocol error.
-var ErrInvalidGrant = errors.New("auth: code is invalid, expired, or already used")
+// Typed errors map to the RFC 6749 §5.2 token-endpoint error codes
+// callers may want to distinguish. ErrServerError covers 5xx responses
+// regardless of whether they carry an OAuth error body — useful when
+// future commands want to retry on transient failures.
+var (
+	ErrInvalidGrant        = errors.New("auth: code is invalid, expired, or already used")
+	ErrInvalidRequest      = errors.New("auth: malformed token request")
+	ErrInvalidClient       = errors.New("auth: client authentication failed")
+	ErrUnsupportedGrant    = errors.New("auth: grant_type not supported")
+	ErrServerError         = errors.New("auth: server error")
+)
+
+var errSentinels = map[string]error{
+	"invalid_grant":          ErrInvalidGrant,
+	"invalid_request":        ErrInvalidRequest,
+	"invalid_client":         ErrInvalidClient,
+	"unsupported_grant_type": ErrUnsupportedGrant,
+}
 
 func randomB64URL(n int) (string, error) {
 	b := make([]byte, n)

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 )
 
 const (
@@ -113,9 +112,6 @@ func ExchangeCode(httpClient *http.Client, apiBase, code string, p PKCE) (TokenR
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 30 * time.Second}
-	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return TokenResponse{}, fmt.Errorf("auth: token request: %w", err)

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -1,0 +1,165 @@
+// Package auth runs the OAuth 2.0 authorization-code+PKCE flow from the
+// CLI side. Pairs with api-platform's /v1/oauth/* endpoints and the
+// /authorize consent page on web-account.
+//
+// Today this implements OOB (urn:ietf:wg:oauth:2.0:oob): the consent
+// page displays the auth code, the user pastes it into the terminal,
+// and we exchange code+verifier for tokens. Custom-scheme delivery
+// (mirrorstack://) is a follow-up that requires platform installers
+// to register the URL handler.
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	// ClientID identifies the CLI to the platform. Matches the seed in
+	// api-platform migration 011_oauth.up.sql.
+	ClientID = "mirrorstack-cli"
+
+	// RedirectURI is the OOB sentinel from RFC 6749 §1.3.1. The auth
+	// server returns the code on the consent page instead of redirecting.
+	RedirectURI = "urn:ietf:wg:oauth:2.0:oob"
+
+	// challengeMethod is the only PKCE method the platform accepts.
+	challengeMethod = "S256"
+)
+
+// PKCE holds the verifier (kept secret in CLI memory) and the challenge
+// (sent to the auth server). The exchange validates that
+// SHA256(verifier) == challenge.
+type PKCE struct {
+	Verifier  string
+	Challenge string
+}
+
+// NewPKCE generates a 32-byte random verifier and its S256 challenge.
+func NewPKCE() (PKCE, error) {
+	verifier, err := randomB64URL(32)
+	if err != nil {
+		return PKCE{}, fmt.Errorf("auth: pkce verifier: %w", err)
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	return PKCE{
+		Verifier:  verifier,
+		Challenge: base64.RawURLEncoding.EncodeToString(sum[:]),
+	}, nil
+}
+
+// AuthorizeURL builds the consent-page URL the user opens in a browser.
+// State is echoed back; today's OOB flow doesn't have a separate
+// callback to validate against, but the auth server still requires the
+// param.
+func AuthorizeURL(webBase, state string, p PKCE) string {
+	q := url.Values{}
+	q.Set("client_id", ClientID)
+	q.Set("redirect_uri", RedirectURI)
+	q.Set("response_type", "code")
+	q.Set("code_challenge", p.Challenge)
+	q.Set("code_challenge_method", challengeMethod)
+	q.Set("state", state)
+	return strings.TrimRight(webBase, "/") + "/authorize?" + q.Encode()
+}
+
+// NewState returns a high-entropy state token. Stored locally; verified
+// equal to the one shown on the success page would be ideal but with OOB
+// the user paste only includes the code, not the state. State here is
+// effectively a CSRF token that isn't exercised end-to-end in OOB. Keep
+// it because the auth server validates the URL has one and the design
+// generalizes when custom-scheme delivery lands (then state IS echoed
+// back via the redirect URL and the CLI can verify).
+func NewState() (string, error) {
+	return randomB64URL(16)
+}
+
+// TokenResponse is the success body of POST /v1/oauth/token (RFC 6749
+// §5.1). MirrorStack's variant: opaque refresh_token in the body for
+// CLI / non-cookie callers.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+// ExchangeCode sends the auth-code + verifier to /v1/oauth/token and
+// returns the tokens. Network errors bubble up wrapped; the server's
+// invalid_grant is surfaced as a typed error so the login command can
+// give a more useful message than the generic description.
+func ExchangeCode(httpClient *http.Client, apiBase, code string, p PKCE) (TokenResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", ClientID)
+	form.Set("code", code)
+	form.Set("code_verifier", p.Verifier)
+	form.Set("redirect_uri", RedirectURI)
+
+	endpoint := strings.TrimRight(apiBase, "/") + "/v1/oauth/token"
+	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return TokenResponse{}, fmt.Errorf("auth: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return TokenResponse{}, fmt.Errorf("auth: token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return TokenResponse{}, fmt.Errorf("auth: read response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		var tr TokenResponse
+		if err := json.Unmarshal(body, &tr); err != nil {
+			return TokenResponse{}, fmt.Errorf("auth: decode token: %w", err)
+		}
+		return tr, nil
+	}
+
+	// Try to parse RFC 6749 §5.2 error body so we can map invalid_grant
+	// to ErrInvalidGrant.
+	var errBody struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	_ = json.Unmarshal(body, &errBody)
+	if errBody.Error == "invalid_grant" {
+		return TokenResponse{}, ErrInvalidGrant
+	}
+	if errBody.Error != "" {
+		return TokenResponse{}, fmt.Errorf("auth: %s: %s", errBody.Error, errBody.ErrorDescription)
+	}
+	return TokenResponse{}, fmt.Errorf("auth: unexpected response %d: %s", resp.StatusCode, string(body))
+}
+
+// ErrInvalidGrant maps to the OAuth invalid_grant error. The login
+// command catches this to suggest re-running rather than dumping a
+// raw protocol error.
+var ErrInvalidGrant = errors.New("auth: code is invalid, expired, or already used")
+
+func randomB64URL(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -1,0 +1,145 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestNewPKCE_VerifierAndChallengeMatch(t *testing.T) {
+	p, err := NewPKCE()
+	if err != nil {
+		t.Fatalf("NewPKCE: %v", err)
+	}
+	if p.Verifier == "" || p.Challenge == "" {
+		t.Fatalf("expected non-empty PKCE pair, got %+v", p)
+	}
+	sum := sha256.Sum256([]byte(p.Verifier))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if p.Challenge != want {
+		t.Errorf("Challenge != SHA256(Verifier) base64url\n got %q\nwant %q", p.Challenge, want)
+	}
+}
+
+func TestNewPKCE_UniquePerCall(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 50; i++ {
+		p, err := NewPKCE()
+		if err != nil {
+			t.Fatalf("NewPKCE: %v", err)
+		}
+		if seen[p.Verifier] {
+			t.Fatalf("duplicate verifier on iteration %d", i)
+		}
+		seen[p.Verifier] = true
+	}
+}
+
+func TestAuthorizeURL_Shape(t *testing.T) {
+	p := PKCE{Verifier: "v", Challenge: "abc"}
+	got := AuthorizeURL("https://example.com", "STATE", p)
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if u.Path != "/authorize" {
+		t.Errorf("path = %q, want /authorize", u.Path)
+	}
+	q := u.Query()
+	cases := map[string]string{
+		"client_id":             ClientID,
+		"redirect_uri":          RedirectURI,
+		"response_type":         "code",
+		"code_challenge":        "abc",
+		"code_challenge_method": "S256",
+		"state":                 "STATE",
+	}
+	for k, want := range cases {
+		if got := q.Get(k); got != want {
+			t.Errorf("%s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestAuthorizeURL_TrimsTrailingSlash(t *testing.T) {
+	p := PKCE{Verifier: "v", Challenge: "c"}
+	got := AuthorizeURL("https://example.com/", "s", p)
+	if !strings.HasPrefix(got, "https://example.com/authorize?") {
+		t.Errorf("got %q, want no double slash before /authorize", got)
+	}
+}
+
+func TestExchangeCode_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/oauth/token" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/x-www-form-urlencoded" {
+			t.Errorf("Content-Type = %q, want form-urlencoded", ct)
+		}
+		_ = r.ParseForm()
+		if r.PostForm.Get("grant_type") != "authorization_code" {
+			t.Errorf("grant_type = %q", r.PostForm.Get("grant_type"))
+		}
+		if r.PostForm.Get("code") != "AUTHCODE" {
+			t.Errorf("code = %q", r.PostForm.Get("code"))
+		}
+		if r.PostForm.Get("code_verifier") != "VERIFIER" {
+			t.Errorf("code_verifier = %q", r.PostForm.Get("code_verifier"))
+		}
+		_ = json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken:  "AT",
+			TokenType:    "Bearer",
+			ExpiresIn:    900,
+			RefreshToken: "RT",
+		})
+	}))
+	defer srv.Close()
+
+	tr, err := ExchangeCode(srv.Client(), srv.URL, "AUTHCODE", PKCE{Verifier: "VERIFIER", Challenge: "C"})
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if tr.AccessToken != "AT" || tr.RefreshToken != "RT" || tr.ExpiresIn != 900 {
+		t.Errorf("token response = %+v", tr)
+	}
+}
+
+func TestExchangeCode_InvalidGrant(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_grant",
+			"error_description": "expired",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := ExchangeCode(srv.Client(), srv.URL, "X", PKCE{Verifier: "v"})
+	if !errors.Is(err, ErrInvalidGrant) {
+		t.Errorf("got %v, want ErrInvalidGrant", err)
+	}
+}
+
+func TestExchangeCode_OtherError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_request",
+			"error_description": "missing client_id",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := ExchangeCode(srv.Client(), srv.URL, "X", PKCE{Verifier: "v"})
+	if err == nil || !strings.Contains(err.Error(), "invalid_request") {
+		t.Errorf("got %v, want error containing invalid_request", err)
+	}
+}

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -128,18 +128,63 @@ func TestExchangeCode_InvalidGrant(t *testing.T) {
 	}
 }
 
-func TestExchangeCode_OtherError(t *testing.T) {
+func TestExchangeCode_TypedSentinels(t *testing.T) {
+	cases := []struct {
+		oauthError string
+		want       error
+	}{
+		{"invalid_grant", ErrInvalidGrant},
+		{"invalid_request", ErrInvalidRequest},
+		{"invalid_client", ErrInvalidClient},
+		{"unsupported_grant_type", ErrUnsupportedGrant},
+	}
+	for _, tc := range cases {
+		t.Run(tc.oauthError, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error":             tc.oauthError,
+					"error_description": "test",
+				})
+			}))
+			defer srv.Close()
+
+			_, err := ExchangeCode(srv.Client(), srv.URL, "X", PKCE{Verifier: "v"})
+			if !errors.Is(err, tc.want) {
+				t.Errorf("got %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestExchangeCode_ServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]string{
-			"error":             "invalid_request",
-			"error_description": "missing client_id",
+			"error":             "server_error",
+			"error_description": "boom",
 		})
 	}))
 	defer srv.Close()
 
 	_, err := ExchangeCode(srv.Client(), srv.URL, "X", PKCE{Verifier: "v"})
-	if err == nil || !strings.Contains(err.Error(), "invalid_request") {
-		t.Errorf("got %v, want error containing invalid_request", err)
+	if !errors.Is(err, ErrServerError) {
+		t.Errorf("got %v, want ErrServerError", err)
+	}
+}
+
+func TestExchangeCode_UnknownError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "made_up_code",
+			"error_description": "x",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := ExchangeCode(srv.Client(), srv.URL, "X", PKCE{Verifier: "v"})
+	if err == nil || !strings.Contains(err.Error(), "made_up_code") {
+		t.Errorf("got %v, want error containing made_up_code", err)
 	}
 }

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1,0 +1,32 @@
+// Package browser opens URLs in the user's default web browser.
+//
+// Best-effort: callers should ALWAYS print the URL alongside the open
+// attempt so the user can copy-paste if auto-open fails (headless env,
+// SSH session, browser crashed, etc.).
+package browser
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+// Open tries to open url in the user's default browser. Returns nil on
+// success (the OS handler accepted the request — not necessarily that
+// the browser actually loaded the page).
+func Open(url string) error {
+	cmd, args := openCommand(url)
+	return exec.Command(cmd, args...).Start()
+}
+
+func openCommand(url string) (string, []string) {
+	switch runtime.GOOS {
+	case "darwin":
+		return "open", []string{url}
+	case "windows":
+		// rundll32 is the historical low-friction way to invoke the
+		// default protocol handler without needing a shell.
+		return "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	default:
+		return "xdg-open", []string{url}
+	}
+}

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -1,9 +1,11 @@
 // Package credentials reads and writes the CLI's persisted OAuth tokens.
 //
-// File location is os.UserConfigDir() + "/mirrorstack/credentials.json"
+// File location is os.UserConfigDir() + "/mirrorstack/cli/credentials.json"
 // (~/.config on Linux, ~/Library/Application Support on macOS,
-// %APPDATA% on Windows). Mode 0600 — same trust level as ~/.aws/credentials
-// and ~/.npmrc.
+// %APPDATA% on Windows). The `cli` segment namespaces this away from
+// any future MirrorStack tools (SDKs, daemons, GUIs) that might also
+// want config under ~/.config/mirrorstack/. Mode 0600 — same trust
+// level as ~/.aws/credentials.
 package credentials
 
 import (
@@ -34,7 +36,7 @@ func Path() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("credentials: locate config dir: %w", err)
 	}
-	return filepath.Join(dir, "mirrorstack", "credentials.json"), nil
+	return filepath.Join(dir, "mirrorstack", "cli", "credentials.json"), nil
 }
 
 // Save writes creds atomically with mode 0600. Atomic = write to a

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -54,12 +54,9 @@ func Save(c Credentials) error {
 		return fmt.Errorf("credentials: temp file: %w", err)
 	}
 	tmpPath := tmp.Name()
-	defer func() {
-		// Best-effort cleanup if we error out before the rename.
-		if _, statErr := os.Stat(tmpPath); statErr == nil {
-			_ = os.Remove(tmpPath)
-		}
-	}()
+	// Best-effort cleanup if we error out before the rename. After a
+	// successful Rename below the temp is gone and Remove is a no-op.
+	defer func() { _ = os.Remove(tmpPath) }()
 
 	if err := tmp.Chmod(0o600); err != nil {
 		_ = tmp.Close()

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -1,0 +1,103 @@
+// Package credentials reads and writes the CLI's persisted OAuth tokens.
+//
+// File location is os.UserConfigDir() + "/mirrorstack/credentials.json"
+// (~/.config on Linux, ~/Library/Application Support on macOS,
+// %APPDATA% on Windows). Mode 0600 — same trust level as ~/.aws/credentials
+// and ~/.npmrc.
+package credentials
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Credentials is the on-disk shape. Issued by /v1/oauth/token; the CLI
+// attaches access_token to every authenticated request and uses
+// refresh_token to rotate it via /v1/auth/sessions/refresh once expired.
+type Credentials struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+// ErrNotFound is returned by Load when no credentials file exists.
+// Callers should treat this as "not logged in" rather than a hard error.
+var ErrNotFound = errors.New("credentials: not found (run `mirrorstack login`)")
+
+// Path returns the credentials file path. Created lazily by Save.
+func Path() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("credentials: locate config dir: %w", err)
+	}
+	return filepath.Join(dir, "mirrorstack", "credentials.json"), nil
+}
+
+// Save writes creds atomically with mode 0600. Atomic = write to a
+// temp file in the same directory, then rename — protects against
+// truncated files if the process is killed mid-write.
+func Save(c Credentials) error {
+	path, err := Path()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("credentials: create dir: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".credentials.*.tmp")
+	if err != nil {
+		return fmt.Errorf("credentials: temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		// Best-effort cleanup if we error out before the rename.
+		if _, statErr := os.Stat(tmpPath); statErr == nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("credentials: chmod: %w", err)
+	}
+	enc := json.NewEncoder(tmp)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(c); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("credentials: encode: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("credentials: close: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("credentials: rename: %w", err)
+	}
+	return nil
+}
+
+// Load reads the credentials file. Returns ErrNotFound if missing.
+func Load() (Credentials, error) {
+	path, err := Path()
+	if err != nil {
+		return Credentials{}, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Credentials{}, ErrNotFound
+		}
+		return Credentials{}, fmt.Errorf("credentials: open: %w", err)
+	}
+	defer f.Close()
+
+	var c Credentials
+	if err := json.NewDecoder(f).Decode(&c); err != nil {
+		return Credentials{}, fmt.Errorf("credentials: decode: %w", err)
+	}
+	return c, nil
+}

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -1,0 +1,103 @@
+package credentials
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// withTempConfigDir redirects os.UserConfigDir() to a t.TempDir() for the
+// duration of the test. Uses the same env var the os package consults
+// per platform.
+func withTempConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	switch runtime.GOOS {
+	case "darwin":
+		t.Setenv("HOME", dir)
+		return filepath.Join(dir, "Library", "Application Support")
+	case "windows":
+		t.Setenv("APPDATA", dir)
+		return dir
+	default:
+		t.Setenv("XDG_CONFIG_HOME", dir)
+		return dir
+	}
+}
+
+func TestSaveLoad_Roundtrip(t *testing.T) {
+	withTempConfigDir(t)
+
+	want := Credentials{
+		AccessToken:  "AT",
+		RefreshToken: "RT",
+		ExpiresAt:    time.Now().Add(15 * time.Minute).UTC().Truncate(time.Second),
+	}
+	if err := Save(want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.AccessToken != want.AccessToken || got.RefreshToken != want.RefreshToken {
+		t.Errorf("tokens mismatch:\n got %+v\nwant %+v", got, want)
+	}
+	if !got.ExpiresAt.Equal(want.ExpiresAt) {
+		t.Errorf("ExpiresAt = %v, want %v", got.ExpiresAt, want.ExpiresAt)
+	}
+}
+
+func TestLoad_NotFound(t *testing.T) {
+	withTempConfigDir(t)
+
+	_, err := Load()
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestSave_FileMode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file modes don't map cleanly on Windows")
+	}
+	withTempConfigDir(t)
+
+	if err := Save(Credentials{AccessToken: "AT"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	path, err := Path()
+	if err != nil {
+		t.Fatalf("Path: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("mode = %o, want 0600", mode)
+	}
+}
+
+func TestSave_Atomic_NoTempLeftBehind(t *testing.T) {
+	withTempConfigDir(t)
+
+	if err := Save(Credentials{AccessToken: "AT"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	path, _ := Path()
+	dir := filepath.Dir(path)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != filepath.Base(path) {
+			t.Errorf("unexpected file in config dir: %s", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
Closes #5.

Final piece of the auth pipeline: api-platform#103 + #107 (server) → web-account#27 (consent page) → this PR (CLI command).

## Summary
\`mirrorstack login\` runs OAuth 2.0 authorization-code + PKCE against the platform's \`/v1/oauth/*\` endpoints. Defaults to **OOB mode** (\`urn:ietf:wg:oauth:2.0:oob\`) — consent page shows the auth code, user pastes into the terminal, CLI exchanges code+verifier for tokens. Claude-Code-style flow; works in SSH dev boxes / sandboxed terminals without per-OS install ceremony.

## What you get

\`\`\`
$ mirrorstack login
Opening your browser to sign in:

  https://account.mirrorstack.ai/authorize?client_id=mirrorstack-cli&code_challenge=…

After approving in the browser, paste the code here: <user-pastes-43-char-code>

Signed in. Tokens saved to /Users/foo/.config/mirrorstack/credentials.json
\`\`\`

## Architecture

| Concern | Where |
|---|---|
| PKCE generation, AuthorizeURL builder, /token exchange | \`internal/auth\` |
| Atomic 0600 token write to \`os.UserConfigDir()/mirrorstack/credentials.json\` | \`internal/credentials\` |
| Best-effort browser auto-open (open/xdg-open/rundll32) — URL always printed as a fallback | \`internal/browser\` |
| Command orchestration, error formatting, env-override config | \`cmd/login.go\` |

Env overrides for local dev:
- \`MIRRORSTACK_API_URL\` (default \`https://account.mirrorstack.ai\`)
- \`MIRRORSTACK_WEB_URL\` (default = same as API)

## Test plan
- [x] \`go build / vet / test\` all green
- [x] Unit tests: PKCE roundtrip + uniqueness, AuthorizeURL shape, ExchangeCode happy/invalid_grant/other_error, credentials roundtrip + ErrNotFound + 0600 mode + atomic-write-no-temp-leak
- [x] Smoke test against local api-platform + web-account: \`MIRRORSTACK_API_URL=http://localhost:8081 MIRRORSTACK_WEB_URL=http://localhost:3000 mirrorstack login\` produces the correctly-shaped \`/authorize?...\` URL
- [ ] Custom-scheme delivery (\`mirrorstack://\`) — follow-up; needs platform installers (.app on macOS, .desktop on Linux, registry on Windows)
- [ ] \`mirrorstack logout\` / \`whoami\` — small follow-up PRs
- [ ] Refresh-token rotation — wiring lands when we ship the first command that calls an authenticated endpoint

## Notes
- 43-char OOB code is RFC 6749's classic format; users paste it once per CLI install
- Friendly \`invalid_grant\` message: *"code didn't work — it may have expired or already been used. Run \`mirrorstack login\` again to get a fresh one."*
- 30s HTTP timeout, 64KB response body cap on /token

🤖 Generated with [Claude Code](https://claude.com/claude-code)