### PR TITLE
feat(scaffold): match SDK v0.2.0 — Slug, v0.1.0-dev, Need callback

### DIFF
--- a/src/commands/module/scaffold.rs
+++ b/src/commands/module/scaffold.rs
@@ -139,10 +139,65 @@ mod tests {
     }
 
     #[test]
+    fn render_substitutes_slug_into_config_slug() {
+        // Slug field is the SDK v0.2.0 catalog handle. The scaffolded
+        // module needs it set so the manifest carries it from day one;
+        // missing-slug behavior (dev-only mode) is for hand-written
+        // pre-publish modules, not the CLI scaffold.
+        let out = render(MAIN_GO, &ins("oauth", "OAuth"));
+        assert!(
+            out.contains(r#"Slug: "oauth""#),
+            "rendered main.go missing Config.Slug substitution"
+        );
+    }
+
+    #[test]
+    fn render_versions_default_is_dev_prerelease() {
+        // Pre-1.0 dev builds use `v0.1.0-dev` so `mirrorstack publish` can
+        // refuse `-dev` versions in prod by convention. Promotion
+        // happens at publish time. See docs/module-identity-and-storage-prefix.md.
+        let out = render(MAIN_GO, &ins("media", "Media"));
+        assert!(
+            out.contains(r#""v0.1.0-dev": {App: "0001"}"#),
+            "expected v0.1.0-dev as scaffold default version"
+        );
+        assert!(!out.contains(r#""v0.1.0": {App: "0001"}"#));
+    }
+
+    #[test]
+    fn render_dependson_example_matches_v0_2_shape() {
+        // The doc-comment example must reflect the v0.2.0 contract:
+        // owner-prefixed id with version constraint, plus the Need
+        // callback declaring tables/events. The pre-v0.2.0 bare-id
+        // example (`ms.DependsOn("oauth-core")`) misled scaffolded
+        // modules into a shape the catalog won't accept anymore.
+        let out = render(MAIN_GO, &ins("media", "Media"));
+        assert!(
+            out.contains(r#"ms.DependsOn("@anna/oauth@^1.0.0", func(n *ms.Need)"#),
+            "DependsOn example must use @<owner>/<id>@<version> + Need callback"
+        );
+        assert!(
+            !out.contains(r#"ms.DependsOn("oauth-core")"#),
+            "stale bare-id DependsOn example still present"
+        );
+    }
+
+    #[test]
     fn render_substitutes_in_go_mod() {
         let out = render(GO_MOD, &ins("media", "Media"));
         assert!(out.starts_with("module media\n"));
         assert!(!out.contains("__MS_SLUG__"));
+    }
+
+    #[test]
+    fn render_go_mod_pins_sdk_v0_2() {
+        // Scaffolded modules must link against SDK v0.2.0+ to get Need /
+        // OptionalDependOn — the template's main.go uses both.
+        let out = render(GO_MOD, &ins("media", "Media"));
+        assert!(
+            out.contains("github.com/mirrorstack-ai/app-module-sdk v0.2.0"),
+            "go.mod must pin SDK v0.2.0 to match scaffolded API surface"
+        );
     }
 
     #[test]

--- a/templates/module/go.mod.tmpl
+++ b/templates/module/go.mod.tmpl
@@ -4,5 +4,5 @@ go 1.26
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5
-	github.com/mirrorstack-ai/app-module-sdk v0.1.1
+	github.com/mirrorstack-ai/app-module-sdk v0.2.0
 )

--- a/templates/module/main.go.tmpl
+++ b/templates/module/main.go.tmpl
@@ -29,11 +29,18 @@ func main() {
 		// changing this. Renaming this WOULD require migrating every schema
 		// and table whose name is derived from it.
 		ID:   "__MS_MODULE_ID__",
+		// Slug is the catalog handle (e.g. "oauth"). Mutable via catalog UI;
+		// the storage prefix at install time is <username>_<slug>_. Renames
+		// force a new published version with auto-generated rename migrations.
+		Slug: "__MS_SLUG__",
 		Name: "__MS_NAME__",
 		Icon: "extension",
 		SQL:  sqlFS,
 		Versions: map[string]system.MigrationVersions{
-			"v0.1.0": {App: "0001"},
+			// `-dev` prerelease tag distinguishes "iterating locally" from
+			// "real release". `mirrorstack publish` prompts to promote it
+			// before shipping; CI / prod refuses `-dev` versions.
+			"v0.1.0-dev": {App: "0001"},
 		},
 	}); err != nil {
 		log.Fatalf("mirrorstack: init failed: %v", err)
@@ -42,8 +49,15 @@ func main() {
 	ms.Describe("Replace this description with your module's purpose.")
 
 	// Required deps go here — these become install-time preconditions.
+	// Use @<owner>/<id>@<semver> for the spec; the optional callback
+	// declares which relations and events this module reads from the dep.
+	// The catalog validates names at install time and surfaces them for
+	// app-owner approval before issuing GRANT SELECT.
 	//
-	//	ms.DependsOn("oauth-core")
+	//	ms.DependsOn("@anna/oauth@^1.0.0", func(n *ms.Need) {
+	//	    n.Table("oauth_users")
+	//	    n.Event("user.signed_in")
+	//	})
 
 	for _, hook := range postInitHooks {
 		hook()


### PR DESCRIPTION
## Summary

Updates the module scaffold so `mirrorstack module init` produces source trees that match the SDK v0.2.0 contract end-to-end. Three template fixes plus a SDK pin bump:

| Change | Where | Why |
|---|---|---|
| Add `Slug: "__MS_SLUG__"` to `ms.Init(ms.Config{...})` | `templates/module/main.go.tmpl` | SDK v0.2.0 made `Slug` part of Config; manifest carries it from day one. The `__MS_SLUG__` token was already in `scaffold.rs` and substituted into `go.mod` / response bodies — just wasn't wired into `main.go`'s `ms.Init` call. |
| Default `Versions` key `v0.1.0` → `v0.1.0-dev` | `templates/module/main.go.tmpl` | The `-dev` prerelease tag distinguishes "iterating locally" from "real release". `mirrorstack publish` (planned) prompts to promote it before shipping. Per `docs/module-identity-and-storage-prefix.md`. |
| Replace stale `ms.DependsOn("oauth-core")` doc-comment example | `templates/module/main.go.tmpl` | Pre-v0.2.0 bare-id form. New example uses `@<owner>/<id>@<version>` plus the `func(n *ms.Need) { n.Table(...); n.Event(...) }` callback shape — the actual contract scaffolded modules need. |
| Pin SDK to `v0.2.0` | `templates/module/go.mod.tmpl` | Was `v0.1.1`. Scaffolded modules need `Need` / `OptionalDependOn` / `Config.Slug` from v0.2.0 to compile. |

## What scaffolded modules look like now

```go
ms.Init(ms.Config{
    ID:   "mbb8a3f8b...",       // platform-assigned UUID
    Slug: "my-module",           // catalog handle
    Name: "My Module",
    Icon: "extension",
    SQL:  sqlFS,
    Versions: map[string]system.MigrationVersions{
        "v0.1.0-dev": {App: "0001"},
    },
})

// Required deps go here — these become install-time preconditions.
// Use @<owner>/<id>@<semver> for the spec; the optional callback
// declares which relations and events this module reads from the dep.
//
//	ms.DependsOn("@anna/oauth@^1.0.0", func(n *ms.Need) {
//	    n.Table("oauth_users")
//	    n.Event("user.signed_in")
//	})
```

## Test plan

- [x] `cargo build --all-targets` clean
- [x] `cargo test --quiet` clean — 64 tests pass (4 new: `render_substitutes_slug_into_config_slug`, `render_versions_default_is_dev_prerelease`, `render_dependson_example_matches_v0_2_shape`, `render_go_mod_pins_sdk_v0_2`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Reviewer's quick-glance check

In `templates/module/main.go.tmpl`:
- Line ~31: `ID: "__MS_MODULE_ID__"` — unchanged
- Line ~32 (NEW): `Slug: "__MS_SLUG__"`
- Line ~36 (CHANGED): key is `"v0.1.0-dev"`
- Lines 44-54 (CHANGED): updated `DependsOn` example with `Need` callback

In `templates/module/go.mod.tmpl`:
- Line 7 (CHANGED): SDK pin `v0.1.1` → `v0.2.0`

## Out of scope

- `mirrorstack publish` command itself (planned PR 2 of `module-identity-and-storage-prefix.md`). The template's `v0.1.0-dev` default is set up for it; the publish-time `-dev` promotion logic lands separately.
- `OptionalDependOn` / `OnEvent` example in the events template — separate small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)