### PR TITLE
fix: point default base URLs at the path-mapped prod ingress

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1770,8 +1770,7 @@ mod tests {
         let _m = server
             .mock("POST", "/v1/apps/a-1/deploys")
             .match_body(mockito::Matcher::JsonString(
-                r#"{"env":"prod","files":[{"path":"index.html","size":5,"sha256":"aa"}]}"#
-                    .into(),
+                r#"{"env":"prod","files":[{"path":"index.html","size":5,"sha256":"aa"}]}"#.into(),
             ))
             .with_status(422)
             .with_body(
@@ -1831,15 +1830,8 @@ mod tests {
             .with_body(json!({"active_deploy_id": "d-1"}).to_string())
             .create();
 
-        let a = activate_app_stage(
-            &test_client(),
-            &server.url(),
-            "AT",
-            "a-1",
-            "prod",
-            "d-1",
-        )
-        .expect("ok");
+        let a = activate_app_stage(&test_client(), &server.url(), "AT", "a-1", "prod", "d-1")
+            .expect("ok");
         assert_eq!(a.active_deploy_id, "d-1");
     }
 
@@ -1852,15 +1844,8 @@ mod tests {
             .with_body(r#"{"error":{"code":"deploy_not_ready","message":"deploy is not ready"}}"#)
             .create();
 
-        let err = activate_app_stage(
-            &test_client(),
-            &server.url(),
-            "AT",
-            "a-1",
-            "prod",
-            "d-1",
-        )
-        .unwrap_err();
+        let err = activate_app_stage(&test_client(), &server.url(), "AT", "a-1", "prod", "d-1")
+            .unwrap_err();
         match err {
             ApiError::Server { status, code, .. } => {
                 assert_eq!(status, 409);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,16 +12,18 @@ mod logout;
 mod module;
 mod whoami;
 
-/// Default api-platform account-service host. Override per-invocation with
+/// Default api-platform account-service base. Prod path-routes each service
+/// under an API-Gateway mapping key (`/account`, `/apps`, `/dispatch`) — a
+/// bare-host request 403s at the edge. Override per-invocation with
 /// `MIRRORSTACK_API_URL` (or via `.env`).
-pub(crate) const DEFAULT_API_BASE: &str = "https://api.mirrorstack.ai";
+pub(crate) const DEFAULT_API_BASE: &str = "https://api.mirrorstack.ai/account";
 
 /// Default api-platform applications-service host. Modules and apps live
 /// on a separate Lambda from the account service, but in prod both are
 /// exposed under the same `api.mirrorstack.ai` hostname (path-routed at
 /// the ingress). Local dev uses port 8082 — set via `.env`. Override
 /// with `MIRRORSTACK_APPS_API_URL`.
-pub(crate) const DEFAULT_APPS_API_BASE: &str = "https://api.mirrorstack.ai";
+pub(crate) const DEFAULT_APPS_API_BASE: &str = "https://api.mirrorstack.ai/apps";
 
 /// Default web-account host. Override with `MIRRORSTACK_WEB_URL`.
 pub(crate) const DEFAULT_WEB_BASE: &str = "https://account.mirrorstack.ai";
@@ -30,7 +32,7 @@ pub(crate) const DEFAULT_WEB_BASE: &str = "https://account.mirrorstack.ai";
 /// reached under the same `api.mirrorstack.ai` hostname in prod via
 /// path-routed ingress. Local dev uses port 8083 — set via `.env`.
 /// Override with `MIRRORSTACK_DISPATCH_URL`.
-pub(crate) const DEFAULT_DISPATCH_BASE: &str = "https://api.mirrorstack.ai";
+pub(crate) const DEFAULT_DISPATCH_BASE: &str = "https://api.mirrorstack.ai/dispatch";
 
 pub(crate) const ENV_API_URL: &str = "MIRRORSTACK_API_URL";
 pub(crate) const ENV_APPS_API_URL: &str = "MIRRORSTACK_APPS_API_URL";

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,9 +50,6 @@ fn find_dotenv_upward() -> Option<PathBuf> {
         if candidate.is_file() {
             return Some(candidate);
         }
-        match dir.parent() {
-            Some(parent) => dir = parent,
-            None => return None,
-        }
+        dir = dir.parent()?;
     }
 }


### PR DESCRIPTION
## Problem

Prod exposes account/apps/dispatch under API-Gateway path-mapping keys (`/account`, `/apps`, `/dispatch`); the root mapping is deliberately unmapped. The CLI's built-in defaults are bare `https://api.mirrorstack.ai`, so every out-of-the-box command 403s at the Cloudflare/API-GW edge — e.g. `mirrorstack login` POSTs `/v1/oauth/token` at the root and dies. Verified live: `<prefix>/healthz` = 200 for all three services, bare `/healthz` = 403.

## Fix

`DEFAULT_API_BASE` → `https://api.mirrorstack.ai/account`, `DEFAULT_APPS_API_BASE` → `…/apps`, `DEFAULT_DISPATCH_BASE` → `…/dispatch`. `DEFAULT_WEB_BASE` (account.mirrorstack.ai) was already correct. Local dev unaffected — `.env` `MIRRORSTACK_*_URL` overrides keep winning.

## Verification

`cargo build` + full test suite green (156 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)