### PR TITLE
feat: app deploy command — bundle, upload, activate (M4)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -562,6 +562,191 @@ pub fn create_app(
     })
 }
 
+/// GET /v1/apps/{ref} — the caller's app by ID or slug (the platform
+/// resolves either shape). Member-scoped: `Ok(None)` on 404, which covers
+/// both "does not exist" and "exists but the caller isn't a member".
+pub fn get_app(
+    http: &Client,
+    apps_base: &str,
+    access_token: &str,
+    app_ref: &str,
+) -> Result<Option<App>, ApiError> {
+    let endpoint = format!("{}/v1/apps/{}", apps_base.trim_end_matches('/'), app_ref);
+
+    let resp = http
+        .get(&endpoint)
+        .bearer_auth(access_token)
+        .header("Accept", "application/json")
+        .send()?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(Some(resp.json::<App>()?));
+    }
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(ApiError::Unauthenticated);
+    }
+    Err(unexpected_body_error(resp))
+}
+
+/// One file of an app deploy's manifest, as POSTed to the platform.
+#[derive(Debug, Serialize)]
+pub struct DeployFile<'a> {
+    /// Relative forward-slash path under the deploy root (the S3 key tail).
+    pub path: &'a str,
+    pub size: u64,
+    /// Lowercase hex SHA-256 of the file contents.
+    pub sha256: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateAppDeployInput<'a> {
+    pub env: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<&'a str>,
+    pub files: &'a [DeployFile<'a>],
+}
+
+/// One presigned S3 PUT the CLI must perform to ship a deploy file.
+#[derive(Debug, Deserialize)]
+pub struct UploadTarget {
+    /// The manifest path this URL uploads (maps back to the local file).
+    pub path: String,
+    pub url: String,
+    /// Headers the presigned URL was signed with — sent verbatim on the PUT.
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreatedDeploy {
+    pub deploy_id: String,
+    pub uploads: Vec<UploadTarget>,
+}
+
+/// POST /v1/apps/{appId}/deploys — register a pending deploy and mint one
+/// presigned S3 PUT per manifest file (15-minute expiry). Owner/admin
+/// gated; the platform re-validates the manifest (≤500 files, ≤25MB
+/// total, safe relative paths) and surfaces violations as error envelopes.
+pub fn create_app_deploy(
+    http: &Client,
+    apps_base: &str,
+    access_token: &str,
+    app_id: &str,
+    input: &CreateAppDeployInput,
+) -> Result<CreatedDeploy, ApiError> {
+    let endpoint = format!(
+        "{}/v1/apps/{}/deploys",
+        apps_base.trim_end_matches('/'),
+        app_id
+    );
+
+    let resp = http
+        .post(&endpoint)
+        .bearer_auth(access_token)
+        .header("Accept", "application/json")
+        .json(input)
+        .send()?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp.json::<CreatedDeploy>()?);
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(ApiError::Unauthenticated);
+    }
+    Err(envelope_error(resp))
+}
+
+/// Body of a successful finalize: the deploy's new status (`ready`).
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)] // status is part of the API surface; deploy treats 2xx as ready
+pub struct DeployStatus {
+    pub status: String,
+}
+
+/// POST /v1/apps/{appId}/deploys/{deployId}/finalize — the platform spot
+/// checks the uploaded objects (HeadObject on a sample) and flips the
+/// deploy to `ready`. A missing object is a 4xx envelope, not a 200 with
+/// a failed status.
+pub fn finalize_app_deploy(
+    http: &Client,
+    apps_base: &str,
+    access_token: &str,
+    app_id: &str,
+    deploy_id: &str,
+) -> Result<DeployStatus, ApiError> {
+    let endpoint = format!(
+        "{}/v1/apps/{}/deploys/{}/finalize",
+        apps_base.trim_end_matches('/'),
+        app_id,
+        deploy_id
+    );
+
+    let resp = http
+        .post(&endpoint)
+        .bearer_auth(access_token)
+        .header("Accept", "application/json")
+        .send()?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp.json::<DeployStatus>()?);
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(ApiError::Unauthenticated);
+    }
+    Err(envelope_error(resp))
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)] // active_deploy_id is part of the API surface; deploy echoes its own id
+pub struct ActivatedStage {
+    pub active_deploy_id: String,
+}
+
+/// POST /v1/apps/{appId}/stages/{env}/activate — point the stage at a
+/// `ready` deploy. The platform rewrites the edge manifest so the change
+/// is live within the worker's cache TTL (~30s).
+pub fn activate_app_stage(
+    http: &Client,
+    apps_base: &str,
+    access_token: &str,
+    app_id: &str,
+    env: &str,
+    deploy_id: &str,
+) -> Result<ActivatedStage, ApiError> {
+    #[derive(Serialize)]
+    struct Body<'a> {
+        deploy_id: &'a str,
+    }
+    let endpoint = format!(
+        "{}/v1/apps/{}/stages/{}/activate",
+        apps_base.trim_end_matches('/'),
+        app_id,
+        env
+    );
+
+    let resp = http
+        .post(&endpoint)
+        .bearer_auth(access_token)
+        .header("Accept", "application/json")
+        .json(&Body { deploy_id })
+        .send()?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp.json::<ActivatedStage>()?);
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(ApiError::Unauthenticated);
+    }
+    Err(envelope_error(resp))
+}
+
 /// Body of a successful `POST /v1/auth/sessions/refresh`. The platform
 /// rotates the refresh token on every refresh (replay defense), so we
 /// must persist the new one back to credentials. expires_at is RFC3339
@@ -645,6 +830,34 @@ pub fn revoke_session(
         return Err(ApiError::Unauthenticated);
     }
     Err(unexpected_body_error(resp))
+}
+
+/// Common tail for non-success responses that may carry the platform's
+/// structured error envelope: `{"error":{code,message}}` becomes
+/// [`ApiError::Server`] so callers can branch on the code, anything else
+/// falls through to [`ApiError::Unexpected`] with the raw body.
+fn envelope_error(resp: Response) -> ApiError {
+    let status = resp.status().as_u16();
+    let body = match http::read_capped(resp) {
+        Ok(b) => b,
+        Err(e) => {
+            return ApiError::Unexpected {
+                status,
+                body: format!("(read body failed: {e})"),
+            };
+        }
+    };
+    if let Ok(env) = serde_json::from_slice::<ErrorEnvelope>(&body) {
+        return ApiError::Server {
+            status,
+            code: env.error.code,
+            message: env.error.message,
+        };
+    }
+    ApiError::Unexpected {
+        status,
+        body: String::from_utf8_lossy(&body).into_owned(),
+    }
 }
 
 /// Common tail for unexpected (non-success, non-typed) responses: read
@@ -1462,6 +1675,196 @@ mod tests {
             ApiError::Server { status, code, .. } => {
                 assert_eq!(status, 503);
                 assert_eq!(code, "tunnel_offline");
+            }
+            other => panic!("expected Server, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn get_app_200_returns_some() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("GET", "/v1/apps/my-app")
+            .match_header("authorization", "Bearer AT")
+            .with_status(200)
+            .with_body(
+                json!({
+                    "id": "a-1",
+                    "name": "My App",
+                    "slug": "my-app",
+                    "owner_id": "u-1"
+                })
+                .to_string(),
+            )
+            .create();
+
+        let a = get_app(&test_client(), &server.url(), "AT", "my-app").expect("ok");
+        assert!(a.is_some());
+        assert_eq!(a.unwrap().id, "a-1");
+    }
+
+    #[test]
+    fn get_app_404_returns_none() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("GET", "/v1/apps/nope")
+            .with_status(404)
+            .with_body(r#"{"error":{"code":"not_found","message":"app not found"}}"#)
+            .create();
+
+        let a = get_app(&test_client(), &server.url(), "AT", "nope").expect("ok");
+        assert!(a.is_none());
+    }
+
+    #[test]
+    fn create_app_deploy_success() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/apps/a-1/deploys")
+            .match_header("authorization", "Bearer AT")
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"env":"production","note":"first ship","files":[{"path":"index.html","size":5,"sha256":"aa"}]}"#.into(),
+            ))
+            .with_status(201)
+            .with_body(
+                json!({
+                    "deploy_id": "d-1",
+                    "uploads": [{
+                        "path": "index.html",
+                        "url": "https://s3.example/put",
+                        "headers": {"Content-Type": "text/html"}
+                    }]
+                })
+                .to_string(),
+            )
+            .create();
+
+        let d = create_app_deploy(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "a-1",
+            &CreateAppDeployInput {
+                env: "production",
+                note: Some("first ship"),
+                files: &[DeployFile {
+                    path: "index.html",
+                    size: 5,
+                    sha256: "aa",
+                }],
+            },
+        )
+        .expect("ok");
+        assert_eq!(d.deploy_id, "d-1");
+        assert_eq!(d.uploads.len(), 1);
+        assert_eq!(d.uploads[0].path, "index.html");
+        assert_eq!(
+            d.uploads[0].headers.get("Content-Type").map(String::as_str),
+            Some("text/html")
+        );
+    }
+
+    #[test]
+    fn create_app_deploy_omits_note_when_none_and_surfaces_422() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/apps/a-1/deploys")
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"env":"production","files":[{"path":"index.html","size":5,"sha256":"aa"}]}"#
+                    .into(),
+            ))
+            .with_status(422)
+            .with_body(
+                r#"{"error":{"code":"deploy_too_large","message":"total size exceeds 25MB"}}"#,
+            )
+            .create();
+
+        let err = create_app_deploy(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "a-1",
+            &CreateAppDeployInput {
+                env: "production",
+                note: None,
+                files: &[DeployFile {
+                    path: "index.html",
+                    size: 5,
+                    sha256: "aa",
+                }],
+            },
+        )
+        .unwrap_err();
+        match err {
+            ApiError::Server { status, code, .. } => {
+                assert_eq!(status, 422);
+                assert_eq!(code, "deploy_too_large");
+            }
+            other => panic!("expected Server, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_app_deploy_success() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/apps/a-1/deploys/d-1/finalize")
+            .match_header("authorization", "Bearer AT")
+            .with_status(200)
+            .with_body(json!({"status": "ready"}).to_string())
+            .create();
+
+        let s = finalize_app_deploy(&test_client(), &server.url(), "AT", "a-1", "d-1").expect("ok");
+        assert_eq!(s.status, "ready");
+    }
+
+    #[test]
+    fn activate_app_stage_success() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/apps/a-1/stages/production/activate")
+            .match_header("authorization", "Bearer AT")
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"deploy_id":"d-1"}"#.into(),
+            ))
+            .with_status(200)
+            .with_body(json!({"active_deploy_id": "d-1"}).to_string())
+            .create();
+
+        let a = activate_app_stage(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "a-1",
+            "production",
+            "d-1",
+        )
+        .expect("ok");
+        assert_eq!(a.active_deploy_id, "d-1");
+    }
+
+    #[test]
+    fn activate_app_stage_409_surfaces_code() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/apps/a-1/stages/production/activate")
+            .with_status(409)
+            .with_body(r#"{"error":{"code":"deploy_not_ready","message":"deploy is not ready"}}"#)
+            .create();
+
+        let err = activate_app_stage(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "a-1",
+            "production",
+            "d-1",
+        )
+        .unwrap_err();
+        match err {
+            ApiError::Server { status, code, .. } => {
+                assert_eq!(status, 409);
+                assert_eq!(code, "deploy_not_ready");
             }
             other => panic!("expected Server, got {other:?}"),
         }

--- a/src/commands/app/deploy.rs
+++ b/src/commands/app/deploy.rs
@@ -1,0 +1,565 @@
+//! `mirrorstack app deploy` — ship a static build directory to the
+//! platform's app hosting, served on `https://<slug>.mirrorstack.app`.
+//!
+//! Flow: walk the build dir into a manifest (path + size + sha256), POST
+//! it for presigned S3 PUTs, upload every file (bounded fan-out), finalize
+//! (the platform spot-checks the objects), then activate the deploy on the
+//! stage unless `--no-activate`.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{self, IsTerminal};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use clap::Args;
+use console::style;
+use indicatif::{ProgressBar, ProgressStyle};
+use reqwest::blocking::Client;
+use sha2::{Digest, Sha256};
+
+use crate::api::{self, ApiError, CreateAppDeployInput, DeployFile};
+use crate::commands::{
+    DEFAULT_APPS_API_BASE, ENV_APPS_API_URL, ok_mark, resolve_base, session_expired,
+};
+use crate::credentials;
+use crate::http;
+
+use super::with_spinner;
+
+/// Platform caps on one deploy, mirrored client-side so the failure is a
+/// local error before any bytes move (the server re-validates).
+const MAX_TOTAL_BYTES: u64 = 26_214_400; // 25 MB
+const MAX_FILES: usize = 500;
+
+/// Bounded fan-out for the presigned PUTs. S3 happily takes more, but 8
+/// keeps memory (one file body per in-flight PUT) and socket use small.
+const UPLOAD_CONCURRENCY: usize = 8;
+
+/// Generous per-PUT timeout: the largest legal deploy is 25 MB, which on
+/// a slow uplink can far exceed the 15s used for the JSON API calls.
+const UPLOAD_TIMEOUT: Duration = Duration::from_secs(300);
+
+#[derive(Args)]
+pub struct DeployArgs {
+    /// App ID or slug the deploy belongs to.
+    #[arg(long)]
+    app: String,
+    /// Target stage environment.
+    #[arg(long, default_value = "production")]
+    env: String,
+    /// Build directory to ship. Defaults to cwd. Dotfiles and
+    /// node_modules never upload.
+    #[arg(long)]
+    dir: Option<PathBuf>,
+    /// Free-form note shown in the deploy list (e.g. a commit subject).
+    #[arg(long)]
+    note: Option<String>,
+    /// Upload + finalize only; leave the stage on its current deploy.
+    #[arg(long)]
+    no_activate: bool,
+}
+
+pub fn run(args: DeployArgs) -> Result<()> {
+    let dir = args
+        .dir
+        .clone()
+        .unwrap_or_else(|| std::env::current_dir().expect("cwd"));
+    if !dir.is_dir() {
+        return Err(anyhow!("{} is not a directory", dir.display()));
+    }
+
+    let files = with_spinner("Scanning files…", || build_manifest(&dir))?;
+    let bytes_total: u64 = files.iter().map(|f| f.size).sum();
+
+    let mut creds = credentials::load_or_login_hint()?;
+    let apps_base = resolve_base(ENV_APPS_API_URL, DEFAULT_APPS_API_BASE);
+    let client = http::client(Duration::from_secs(15))?;
+
+    // Resolve --app (ID or slug) to the app row: the deploy endpoints take
+    // the ID, and the final URL needs the slug. Member-scoped, so this
+    // doubles as an access check before any upload work.
+    let app = match credentials::with_refresh_retry(&mut creds, |tok| {
+        api::get_app(&client, &apps_base, tok, &args.app)
+    }) {
+        Ok(Some(a)) => a,
+        Ok(None) => {
+            return Err(anyhow!(
+                "app '{}' not found (pass an app ID or slug you're a member of)",
+                args.app
+            ));
+        }
+        Err(ApiError::Unauthenticated) => return Err(session_expired()),
+        Err(e) => return Err(e.into()),
+    };
+
+    eprintln!(
+        "  {} {} → {} ({} files, {})",
+        style("Deploying:").dim(),
+        style(dir.display()).bold(),
+        style(format!("{}@{}", app.slug, args.env)).cyan().bold(),
+        files.len(),
+        human_bytes(bytes_total)
+    );
+
+    let file_inputs: Vec<DeployFile> = files
+        .iter()
+        .map(|f| DeployFile {
+            path: &f.rel_path,
+            size: f.size,
+            sha256: &f.sha256,
+        })
+        .collect();
+    let created = with_spinner("Creating deploy…", || {
+        credentials::with_refresh_retry(&mut creds, |tok| {
+            api::create_app_deploy(
+                &client,
+                &apps_base,
+                tok,
+                &app.id,
+                &CreateAppDeployInput {
+                    env: &args.env,
+                    note: args.note.as_deref(),
+                    files: &file_inputs,
+                },
+            )
+        })
+    })
+    .map_err(api_err)?;
+
+    // Presigned URLs carry their own auth — a dedicated client without the
+    // bearer token and with an upload-sized timeout.
+    let upload_client = http::client(UPLOAD_TIMEOUT)?;
+    upload_all(&upload_client, &created.uploads, &files)?;
+
+    with_spinner("Finalizing…", || {
+        credentials::with_refresh_retry(&mut creds, |tok| {
+            api::finalize_app_deploy(&client, &apps_base, tok, &app.id, &created.deploy_id)
+        })
+    })
+    .map_err(api_err)?;
+
+    if args.no_activate {
+        eprintln!(
+            "{} deployed {} (not activated)",
+            ok_mark(),
+            style(format!("{}@{}", app.slug, args.env)).cyan().bold()
+        );
+        eprintln!("  {} {}", style("deploy:").dim(), created.deploy_id);
+        eprintln!(
+            "  {} activate it from the app's deployment settings, or re-run without --no-activate",
+            style("next:").dim()
+        );
+        return Ok(());
+    }
+
+    with_spinner("Activating…", || {
+        credentials::with_refresh_retry(&mut creds, |tok| {
+            api::activate_app_stage(
+                &client,
+                &apps_base,
+                tok,
+                &app.id,
+                &args.env,
+                &created.deploy_id,
+            )
+        })
+    })
+    .map_err(api_err)?;
+
+    eprintln!(
+        "{} deployed {}",
+        ok_mark(),
+        style(format!("{}@{}", app.slug, args.env)).cyan().bold()
+    );
+    eprintln!("  {} {}", style("deploy:").dim(), created.deploy_id);
+    eprintln!(
+        "  {} {}",
+        style("url:").dim(),
+        style(format!("https://{}.mirrorstack.app", app.slug))
+            .cyan()
+            .bold()
+    );
+    Ok(())
+}
+
+/// Map the API error vocabulary onto command-level errors, the same shape
+/// the other commands print (`code: message`, login hint on 401).
+fn api_err(e: ApiError) -> anyhow::Error {
+    match e {
+        ApiError::Unauthenticated => session_expired(),
+        ApiError::Server { code, message, .. } => anyhow!("{code}: {message}"),
+        other => other.into(),
+    }
+}
+
+/// One file under the deploy root: its manifest entry plus where to read
+/// the bytes back at upload time.
+#[derive(Debug)]
+struct ManifestFile {
+    /// Forward-slash path relative to the deploy root — the S3 key tail.
+    rel_path: String,
+    abs_path: PathBuf,
+    size: u64,
+    /// Lowercase hex SHA-256 of the contents.
+    sha256: String,
+}
+
+/// Walk `root` into a sorted, validated deploy manifest. Dotfiles and
+/// dot-directories (`.git`, `.env`, `.DS_Store`), `node_modules`, and
+/// symlinks (which could point outside the deploy dir) are skipped — a
+/// deploy is a built static site, not the working tree.
+fn build_manifest(root: &Path) -> Result<Vec<ManifestFile>> {
+    let mut files = Vec::new();
+    walk(root, "", &mut files)?;
+    if files.is_empty() {
+        return Err(anyhow!(
+            "no deployable files under {} (dotfiles and node_modules are skipped)",
+            root.display()
+        ));
+    }
+    files.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+    validate_manifest(&files)?;
+    Ok(files)
+}
+
+fn walk(dir: &Path, prefix: &str, out: &mut Vec<ManifestFile>) -> Result<()> {
+    let entries =
+        std::fs::read_dir(dir).with_context(|| format!("read directory {}", dir.display()))?;
+    for entry in entries {
+        let entry = entry.with_context(|| format!("read directory {}", dir.display()))?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            return Err(anyhow!(
+                "non-UTF-8 file name under {} — rename it to deploy",
+                dir.display()
+            ));
+        };
+        if skip_name(name) {
+            continue;
+        }
+        let rel = if prefix.is_empty() {
+            name.to_string()
+        } else {
+            format!("{prefix}/{name}")
+        };
+        // symlink_metadata (not metadata) so links are detected, not followed.
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("stat {}", entry.path().display()))?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            walk(&entry.path(), &rel, out)?;
+        } else if file_type.is_file() {
+            if !path_valid(&rel) {
+                return Err(anyhow!(
+                    "file path {rel:?} contains a backslash or control character — rename it to deploy"
+                ));
+            }
+            let (size, sha256) = hash_file(&entry.path())?;
+            out.push(ManifestFile {
+                rel_path: rel,
+                abs_path: entry.path(),
+                size,
+                sha256,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Names that never ship: dotfiles/dot-dirs and node_modules (any depth).
+fn skip_name(name: &str) -> bool {
+    name.starts_with('.') || name == "node_modules"
+}
+
+/// The platform's path rules, minus the ones the walk makes impossible by
+/// construction (relative, no `..` segments, no leading `/`).
+fn path_valid(rel: &str) -> bool {
+    !rel.contains('\\') && rel.chars().all(|c| !c.is_control())
+}
+
+/// Client-side mirror of the platform's deploy caps.
+fn validate_manifest(files: &[ManifestFile]) -> Result<()> {
+    if files.len() > MAX_FILES {
+        return Err(anyhow!(
+            "too many files: {} (a deploy is capped at {MAX_FILES})",
+            files.len()
+        ));
+    }
+    let total: u64 = files.iter().map(|f| f.size).sum();
+    if total > MAX_TOTAL_BYTES {
+        return Err(anyhow!(
+            "deploy too large: {} (capped at {})",
+            human_bytes(total),
+            human_bytes(MAX_TOTAL_BYTES)
+        ));
+    }
+    Ok(())
+}
+
+/// Stream a file through SHA-256 without holding it in memory; returns
+/// (size, lowercase hex digest).
+fn hash_file(path: &Path) -> Result<(u64, String)> {
+    let mut file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let size =
+        io::copy(&mut file, &mut hasher).with_context(|| format!("read {}", path.display()))?;
+    Ok((size, format!("{:x}", hasher.finalize())))
+}
+
+/// PUT every presigned upload with a bounded worker pool. The first
+/// failure wins: remaining workers drain out without starting new PUTs,
+/// and its error (tagged with the file path) is returned.
+fn upload_all(
+    client: &Client,
+    uploads: &[api::UploadTarget],
+    files: &[ManifestFile],
+) -> Result<()> {
+    let by_path: HashMap<&str, &ManifestFile> =
+        files.iter().map(|f| (f.rel_path.as_str(), f)).collect();
+    // Every server-issued upload must map back to a manifest file we sent —
+    // anything else means the create response is broken; fail before PUTs.
+    for u in uploads {
+        if !by_path.contains_key(u.path.as_str()) {
+            return Err(anyhow!(
+                "server requested an upload for unknown path {:?}",
+                u.path
+            ));
+        }
+    }
+
+    let pb = upload_progress(uploads.len() as u64);
+    let next = AtomicUsize::new(0);
+    let first_err: Mutex<Option<anyhow::Error>> = Mutex::new(None);
+    std::thread::scope(|s| {
+        for _ in 0..UPLOAD_CONCURRENCY.min(uploads.len()) {
+            s.spawn(|| {
+                loop {
+                    if first_err.lock().expect("uploads mutex").is_some() {
+                        return;
+                    }
+                    let i = next.fetch_add(1, Ordering::Relaxed);
+                    let Some(target) = uploads.get(i) else { return };
+                    let file = by_path[target.path.as_str()];
+                    match upload_one(client, target, &file.abs_path) {
+                        Ok(()) => pb.inc(1),
+                        Err(e) => {
+                            let mut slot = first_err.lock().expect("uploads mutex");
+                            if slot.is_none() {
+                                *slot = Some(e.context(format!("upload {}", target.path)));
+                            }
+                            return;
+                        }
+                    }
+                }
+            });
+        }
+    });
+    pb.finish_and_clear();
+
+    match first_err.into_inner().expect("uploads mutex") {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+/// One presigned S3 PUT: the body is the file verbatim and the headers
+/// are exactly what the URL was signed with — nothing added (no bearer
+/// token; the signature IS the auth).
+fn upload_one(client: &Client, target: &api::UploadTarget, path: &Path) -> Result<()> {
+    let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    let mut req = client.put(&target.url).body(bytes);
+    for (k, v) in &target.headers {
+        req = req.header(k.as_str(), v.as_str());
+    }
+    let resp = req.send()?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = http::read_capped(resp).unwrap_or_default();
+        return Err(anyhow!(
+            "presigned PUT failed: HTTP {} {}",
+            status.as_u16(),
+            String::from_utf8_lossy(&body).trim()
+        ));
+    }
+    Ok(())
+}
+
+/// Counter-style progress for the upload pool. Hidden when stderr isn't
+/// a TTY (same rationale as `with_spinner`: keep CI logs clean).
+fn upload_progress(len: u64) -> ProgressBar {
+    if !std::io::stderr().is_terminal() {
+        return ProgressBar::hidden();
+    }
+    let pb = ProgressBar::new(len);
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.cyan} uploading {pos}/{len}")
+            .unwrap()
+            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+    );
+    pb.enable_steady_tick(Duration::from_millis(80));
+    pb
+}
+
+/// `1023 B` / `4.2 KB` / `25.0 MB` — one decimal above bytes, enough for
+/// a size line capped at 25 MB.
+fn human_bytes(n: u64) -> String {
+    const KB: f64 = 1024.0;
+    let n = n as f64;
+    if n < KB {
+        format!("{n:.0} B")
+    } else if n < KB * KB {
+        format!("{:.1} KB", n / KB)
+    } else {
+        format!("{:.1} MB", n / (KB * KB))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    /// SHA-256 of the 5-byte string "hello".
+    const HELLO_SHA256: &str = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+
+    fn write(root: &Path, rel: &str, body: &str) {
+        let path = root.join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn build_manifest_walks_hashes_and_sorts() {
+        let dir = TempDir::new().unwrap();
+        write(dir.path(), "index.html", "hello");
+        write(dir.path(), "assets/app.js", "console.log(1)");
+        write(dir.path(), "assets/img/logo.svg", "<svg/>");
+
+        let files = build_manifest(dir.path()).expect("ok");
+        let paths: Vec<&str> = files.iter().map(|f| f.rel_path.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec!["assets/app.js", "assets/img/logo.svg", "index.html"]
+        );
+
+        let index = files.iter().find(|f| f.rel_path == "index.html").unwrap();
+        assert_eq!(index.size, 5);
+        assert_eq!(index.sha256, HELLO_SHA256);
+        assert!(index.abs_path.is_file());
+    }
+
+    #[test]
+    fn build_manifest_skips_dotfiles_and_node_modules() {
+        let dir = TempDir::new().unwrap();
+        write(dir.path(), "index.html", "hello");
+        write(dir.path(), ".env", "SECRET=1");
+        write(dir.path(), ".git/config", "[core]");
+        write(dir.path(), "node_modules/pkg/index.js", "x");
+        write(dir.path(), "nested/node_modules/pkg/y.js", "y");
+        write(dir.path(), "nested/.DS_Store", "junk");
+        write(dir.path(), "nested/page.html", "hi");
+
+        let files = build_manifest(dir.path()).expect("ok");
+        let paths: Vec<&str> = files.iter().map(|f| f.rel_path.as_str()).collect();
+        assert_eq!(paths, vec!["index.html", "nested/page.html"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_manifest_skips_symlinks() {
+        let dir = TempDir::new().unwrap();
+        write(dir.path(), "index.html", "hello");
+        std::os::unix::fs::symlink("/etc/hosts", dir.path().join("hosts")).unwrap();
+        std::os::unix::fs::symlink("/etc", dir.path().join("etc-dir")).unwrap();
+
+        let files = build_manifest(dir.path()).expect("ok");
+        let paths: Vec<&str> = files.iter().map(|f| f.rel_path.as_str()).collect();
+        assert_eq!(paths, vec!["index.html"]);
+    }
+
+    #[test]
+    fn build_manifest_empty_dir_errors() {
+        let dir = TempDir::new().unwrap();
+        let err = build_manifest(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("no deployable files"), "{err}");
+    }
+
+    #[test]
+    fn build_manifest_only_skipped_files_errors() {
+        let dir = TempDir::new().unwrap();
+        write(dir.path(), ".env", "SECRET=1");
+        write(dir.path(), "node_modules/x.js", "x");
+        let err = build_manifest(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("no deployable files"), "{err}");
+    }
+
+    fn stub_file(rel_path: &str, size: u64) -> ManifestFile {
+        ManifestFile {
+            rel_path: rel_path.to_string(),
+            abs_path: PathBuf::from(rel_path),
+            size,
+            sha256: HELLO_SHA256.to_string(),
+        }
+    }
+
+    #[test]
+    fn validate_manifest_rejects_too_many_files() {
+        let files: Vec<ManifestFile> = (0..=MAX_FILES)
+            .map(|i| stub_file(&format!("f{i}.txt"), 1))
+            .collect();
+        let err = validate_manifest(&files).unwrap_err();
+        assert!(err.to_string().contains("too many files"), "{err}");
+    }
+
+    #[test]
+    fn validate_manifest_rejects_oversized_total() {
+        let files = vec![stub_file("a.bin", MAX_TOTAL_BYTES), stub_file("b.bin", 1)];
+        let err = validate_manifest(&files).unwrap_err();
+        assert!(err.to_string().contains("deploy too large"), "{err}");
+    }
+
+    #[test]
+    fn validate_manifest_accepts_exact_caps() {
+        let files = vec![stub_file("a.bin", MAX_TOTAL_BYTES)];
+        assert!(validate_manifest(&files).is_ok());
+        let many: Vec<ManifestFile> = (0..MAX_FILES)
+            .map(|i| stub_file(&format!("f{i}.txt"), 1))
+            .collect();
+        assert!(validate_manifest(&many).is_ok());
+    }
+
+    #[test]
+    fn skip_name_cases() {
+        assert!(skip_name(".env"));
+        assert!(skip_name(".git"));
+        assert!(skip_name("node_modules"));
+        assert!(!skip_name("index.html"));
+        assert!(!skip_name("my.node_modules.txt"));
+    }
+
+    #[test]
+    fn path_valid_rejects_backslash_and_control_chars() {
+        assert!(path_valid("assets/app.js"));
+        assert!(path_valid("中文/页面.html"));
+        assert!(!path_valid("assets\\app.js"));
+        assert!(!path_valid("bad\u{7}name.txt"));
+        assert!(!path_valid("bad\nname.txt"));
+    }
+
+    #[test]
+    fn human_bytes_formats() {
+        assert_eq!(human_bytes(512), "512 B");
+        assert_eq!(human_bytes(4302), "4.2 KB");
+        assert_eq!(human_bytes(MAX_TOTAL_BYTES), "25.0 MB");
+    }
+}

--- a/src/commands/app/mod.rs
+++ b/src/commands/app/mod.rs
@@ -18,6 +18,8 @@ use super::{
     ENV_WEB_URL, ok_mark, resolve_base, session_expired,
 };
 
+mod deploy;
+
 #[derive(Args)]
 pub struct AppArgs {
     #[command(subcommand)]
@@ -28,6 +30,10 @@ pub struct AppArgs {
 enum AppCommand {
     /// Create a new application on the platform.
     Create(CreateArgs),
+    /// Deploy a static build directory to app hosting
+    /// (`https://<slug>.mirrorstack.app`). Uploads, finalizes, and
+    /// activates unless --no-activate.
+    Deploy(deploy::DeployArgs),
 }
 
 #[derive(Args)]
@@ -46,6 +52,7 @@ struct CreateArgs {
 pub fn run(args: AppArgs) -> Result<()> {
     match args.command {
         AppCommand::Create(c) => create(c),
+        AppCommand::Deploy(d) => deploy::run(d),
     }
 }
 
@@ -175,7 +182,7 @@ fn derive_slug(name: &str) -> String {
     out
 }
 
-fn with_spinner<T, F>(message: &str, f: F) -> T
+pub(super) fn with_spinner<T, F>(message: &str, f: F) -> T
 where
     F: FnOnce() -> T,
 {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -79,6 +79,7 @@ enum Command {
     /// into apps).
     Module(module::ModuleArgs),
     /// Manage applications on the platform.
+    #[command(visible_alias = "app")]
     Apps(app::AppArgs),
     /// Run modules locally with supporting services. Scans go.work for
     /// monorepo mode; falls back to single-module if only main.go exists.


### PR DESCRIPTION
M4 of core-v2#20 (frozen contract). `mirrorstack app deploy --app <id|slug> [--env production] [--dir] [--note] [--no-activate]` per the repo's module-deploy patterns (Rust — the task sheet said Go in error; repo reality wins). Unit-tested manifest walk + filtering. CI down — cargo test green locally. 🤖 Generated with [Claude Code](https://claude.com/claude-code)