### PR TITLE
feat: command taxonomy — app web deploy + app module *

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Pre-built releases (brew, scoop, deb) coming with the next milestone.
 mirrorstack login           # Sign in via OAuth (PKCE)
 mirrorstack logout          # Revoke the current session and wipe local credentials
 mirrorstack whoami          # Print the currently signed-in user
-mirrorstack module init     # Register a new module on the platform
+mirrorstack app module init # Register a new module on the platform
+mirrorstack app web deploy  # Deploy a static build directory to app hosting
 mirrorstack --help          # Show help
 mirrorstack --version       # Show CLI version
 ```

--- a/src/commands/app/deploy.rs
+++ b/src/commands/app/deploy.rs
@@ -1,4 +1,4 @@
-//! `mirrorstack app deploy` — ship a static build directory to the
+//! `mirrorstack app web deploy` — ship a static build directory to the
 //! platform's app hosting, served on `https://<slug>.mirrorstack.app`.
 //!
 //! Flow: walk the build dir into a manifest (path + size + sha256), POST

--- a/src/commands/app/mod.rs
+++ b/src/commands/app/mod.rs
@@ -30,6 +30,22 @@ pub struct AppArgs {
 enum AppCommand {
     /// Create a new application on the platform.
     Create(CreateArgs),
+    /// Manage the app's web frontend (static hosting on
+    /// `https://<slug>.mirrorstack.app`).
+    Web(WebArgs),
+    /// Manage developer modules (the per-developer reusable units installed
+    /// into apps).
+    Module(super::module::ModuleArgs),
+}
+
+#[derive(Args)]
+pub struct WebArgs {
+    #[command(subcommand)]
+    command: WebCommand,
+}
+
+#[derive(Subcommand)]
+enum WebCommand {
     /// Deploy a static build directory to app hosting
     /// (`https://<slug>.mirrorstack.app`). Uploads, finalizes, and
     /// activates unless --no-activate.
@@ -52,7 +68,10 @@ struct CreateArgs {
 pub fn run(args: AppArgs) -> Result<()> {
     match args.command {
         AppCommand::Create(c) => create(c),
-        AppCommand::Deploy(d) => deploy::run(d),
+        AppCommand::Web(w) => match w.command {
+            WebCommand::Deploy(d) => deploy::run(d),
+        },
+        AppCommand::Module(m) => super::module::run(m),
     }
 }
 

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -165,7 +165,7 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
         let reason = if slug.is_empty() {
             "no main.go"
         } else {
-            "no ID — run `mirrorstack module register`"
+            "no ID — run `mirrorstack app module register`"
         };
         eprintln!(
             "  {} {} ({})",
@@ -177,7 +177,7 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
 
     if ready.is_empty() {
         return Err(anyhow!(
-            "no registered modules to run. Run `mirrorstack module register` first."
+            "no registered modules to run. Run `mirrorstack app module register` first."
         ));
     }
 
@@ -795,7 +795,7 @@ fn open_tunnels(
             }
             Err(tunnel::RegisterError::ModuleNotYours) => {
                 return Err(anyhow!(
-                    "dev: module {} isn't owned by you — only the module owner can open a dev tunnel.\nIf you scaffolded with `mirrorstack module init`, your `Config.ID` should match the platform's record; re-check it under `mirrorstack module list`.",
+                    "dev: module {} isn't owned by you — only the module owner can open a dev tunnel.\nIf you scaffolded with `mirrorstack app module init`, your `Config.ID` should match the platform's record; re-check it under `mirrorstack app module list`.",
                     m.dir.display()
                 ));
             }

--- a/src/commands/dev/module_meta.rs
+++ b/src/commands/dev/module_meta.rs
@@ -47,7 +47,7 @@ pub(super) fn read_module_id(module_dir: &Path) -> Result<String> {
     let meta = read_module_meta(module_dir)?;
     if meta.id.is_empty() {
         return Err(anyhow!(
-            "dev: module {} has no ID set. Run `mirrorstack modules register` first.",
+            "dev: module {} has no ID set. Run `mirrorstack app module register` first.",
             module_dir.display()
         ));
     }
@@ -326,7 +326,7 @@ func main() {
         Name: "Media",
         Icon: "extension",
         Versions: map[string]system.MigrationVersions{
-            // `-dev` marks local iteration; `mirrorstack module deploy`
+            // `-dev` marks local iteration; `mirrorstack app module deploy`
             // promotes it before shipping.
             "v0.1.0-dev": {App: "0001"},
         },

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -75,8 +75,10 @@ enum Command {
     Logout(logout::LogoutArgs),
     /// Print the currently signed-in user.
     Whoami(whoami::WhoamiArgs),
-    /// Manage developer modules (the per-developer reusable units installed
-    /// into apps).
+    /// Deprecated: moved to `mirrorstack app module`. This hidden alias
+    /// keeps existing scripts working and will be removed in a future
+    /// release.
+    #[command(hide = true)]
     Module(module::ModuleArgs),
     /// Manage applications on the platform.
     #[command(visible_alias = "app")]

--- a/src/commands/module/mod.rs
+++ b/src/commands/module/mod.rs
@@ -1,4 +1,6 @@
-//! `mirrorstack module …` — developer module management.
+//! `mirrorstack app module …` — developer module management. (The old
+//! top-level `mirrorstack module …` spelling still works as a hidden,
+//! deprecated alias.)
 //!
 //! Today: `module init` registers the module on the platform AND scaffolds a
 //! local source tree from the SDK template. The scaffolded tree is what
@@ -731,7 +733,7 @@ fn get_owned_module(
     match api::get_module(client, apps_base, access_token, slug) {
         Ok(Some(m)) => Ok(m),
         Ok(None) => Err(anyhow!(
-            "module '{slug}' not found on the platform (run `mirrorstack module register` first)"
+            "module '{slug}' not found on the platform (run `mirrorstack app module register` first)"
         )),
         Err(ApiError::Unauthenticated) => Err(session_expired()),
         Err(e) => Err(e.into()),
@@ -767,7 +769,7 @@ fn record_error_hint(code: &str) -> &'static str {
 fn deploy_error_hint(code: &str) -> &'static str {
     match code {
         "not_found" => {
-            " (the version record vanished mid-deploy — re-run `mirrorstack module deploy`)"
+            " (the version record vanished mid-deploy — re-run `mirrorstack app module deploy`)"
         }
         "invoke_target_invalid" => {
             " (expected a Lambda function name or full ARN, optional :qualifier, [A-Za-z0-9_-]{1,140})"
@@ -1087,7 +1089,7 @@ mod tests {
 
     #[test]
     fn deploy_error_hint_for_known_codes() {
-        assert!(deploy_error_hint("not_found").contains("mirrorstack module deploy"));
+        assert!(deploy_error_hint("not_found").contains("mirrorstack app module deploy"));
         assert!(deploy_error_hint("invoke_target_invalid").contains("ARN"));
         assert_eq!(deploy_error_hint("something_else"), "");
     }

--- a/src/commands/module/scaffold.rs
+++ b/src/commands/module/scaffold.rs
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn render_versions_default_is_dev_prerelease() {
-        // Pre-1.0 dev builds use `v0.1.0-dev` so `mirrorstack module deploy` can
+        // Pre-1.0 dev builds use `v0.1.0-dev` so `mirrorstack app module deploy` can
         // refuse `-dev` versions in CI (--yes) by convention. Promotion
         // happens at deploy time. See docs/module-identity-and-storage-prefix.md.
         let out = render(MAIN_GO, &ins("media", "Media"));

--- a/templates/module/main.go.tmpl
+++ b/templates/module/main.go.tmpl
@@ -38,7 +38,7 @@ func main() {
 		SQL:  sqlFS,
 		Versions: map[string]system.MigrationVersions{
 			// `-dev` prerelease tag distinguishes "iterating locally" from
-			// "real release". `mirrorstack module deploy` prompts to promote
+			// "real release". `mirrorstack app module deploy` prompts to promote
 			// before shipping; CI (--yes) refuses `-dev` versions.
 			"v0.1.0-dev": {App: "0001"},
 		},


### PR DESCRIPTION
Owner-review renames on core-v2#20: `app deploy` → `app web deploy`; top-level `module *` → `app module *` with the old spelling kept as a hidden deprecated alias (about-text says so) — scripts don't break, help output shows only the new tree. Every self-referencing hint (dev flow errors, scaffold templates, README) updated. 174 tests green, no new clippy warnings. 🤖 Generated with [Claude Code](https://claude.com/claude-code)