### PR TITLE
chore: env value production → prod

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1723,7 +1723,7 @@ mod tests {
             .mock("POST", "/v1/apps/a-1/deploys")
             .match_header("authorization", "Bearer AT")
             .match_body(mockito::Matcher::JsonString(
-                r#"{"env":"production","note":"first ship","files":[{"path":"index.html","size":5,"sha256":"aa"}]}"#.into(),
+                r#"{"env":"prod","note":"first ship","files":[{"path":"index.html","size":5,"sha256":"aa"}]}"#.into(),
             ))
             .with_status(201)
             .with_body(
@@ -1745,7 +1745,7 @@ mod tests {
             "AT",
             "a-1",
             &CreateAppDeployInput {
-                env: "production",
+                env: "prod",
                 note: Some("first ship"),
                 files: &[DeployFile {
                     path: "index.html",
@@ -1770,7 +1770,7 @@ mod tests {
         let _m = server
             .mock("POST", "/v1/apps/a-1/deploys")
             .match_body(mockito::Matcher::JsonString(
-                r#"{"env":"production","files":[{"path":"index.html","size":5,"sha256":"aa"}]}"#
+                r#"{"env":"prod","files":[{"path":"index.html","size":5,"sha256":"aa"}]}"#
                     .into(),
             ))
             .with_status(422)
@@ -1785,7 +1785,7 @@ mod tests {
             "AT",
             "a-1",
             &CreateAppDeployInput {
-                env: "production",
+                env: "prod",
                 note: None,
                 files: &[DeployFile {
                     path: "index.html",
@@ -1836,7 +1836,7 @@ mod tests {
             &server.url(),
             "AT",
             "a-1",
-            "production",
+            "prod",
             "d-1",
         )
         .expect("ok");
@@ -1857,7 +1857,7 @@ mod tests {
             &server.url(),
             "AT",
             "a-1",
-            "production",
+            "prod",
             "d-1",
         )
         .unwrap_err();

--- a/src/commands/app/deploy.rs
+++ b/src/commands/app/deploy.rs
@@ -49,7 +49,7 @@ pub struct DeployArgs {
     #[arg(long)]
     app: String,
     /// Target stage environment.
-    #[arg(long, default_value = "production")]
+    #[arg(long, default_value = "prod")]
     env: String,
     /// Build directory to ship. Defaults to cwd. Dotfiles and
     /// node_modules never upload.


### PR DESCRIPTION
Owner decision on core-v2#20: canonical env value is `prod`. Default of `app web deploy --env` + all self-references; API-side rename ships in the same train. Tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)