### PR TITLE
chore: drop deprecated top-level mirrorstack module alias

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -77,11 +77,6 @@ enum Command {
     Logout(logout::LogoutArgs),
     /// Print the currently signed-in user.
     Whoami(whoami::WhoamiArgs),
-    /// Deprecated: moved to `mirrorstack app module`. This hidden alias
-    /// keeps existing scripts working and will be removed in a future
-    /// release.
-    #[command(hide = true)]
-    Module(module::ModuleArgs),
     /// Manage applications on the platform.
     #[command(visible_alias = "app")]
     Apps(app::AppArgs),
@@ -96,7 +91,6 @@ impl Cli {
             Command::Login(args) => login::run(args),
             Command::Logout(args) => logout::run(args),
             Command::Whoami(args) => whoami::run(args),
-            Command::Module(args) => module::run(args),
             Command::Apps(args) => app::run(args),
             Command::Dev(args) => dev::run(args),
         }

--- a/src/commands/module/mod.rs
+++ b/src/commands/module/mod.rs
@@ -1,6 +1,4 @@
-//! `mirrorstack app module …` — developer module management. (The old
-//! top-level `mirrorstack module …` spelling still works as a hidden,
-//! deprecated alias.)
+//! `mirrorstack app module …` — developer module management.
 //!
 //! Today: `module init` registers the module on the platform AND scaffolds a
 //! local source tree from the SDK template. The scaffolded tree is what


### PR DESCRIPTION
## Summary
- Removes the hidden `mirrorstack module *` alias (kept for script compat after cli#45's taxonomy move). `mirrorstack app module *` / `mirrorstack apps module *` are the only spellings now.
- Cleans up the now-stale doc comment referencing the old alias.

## Test plan
- [x] `cargo build` green
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 174 passed
- [x] Manually verified: `mirrorstack module` → `unrecognized subcommand` (exit 2); `mirrorstack app module` and `mirrorstack apps module` both resolve to the module subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)