### PR TITLE
feat: WSS HTTP-relay data plane for dev-tunnel (CLI side)

### DIFF
--- a/src/commands/dev/tunnel.rs
+++ b/src/commands/dev/tunnel.rs
@@ -13,6 +13,7 @@
 //! deferred to Phase 3 per the design doc; this module's enum intentionally
 //! enumerates them so that PR only adds a handler arm.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -345,15 +346,16 @@ pub(super) async fn open(
         .timeout(MANIFEST_FETCH_TIMEOUT)
         .build()
         .context("dev: build manifest-hash http client")?;
-    tokio::spawn(run_tunnel_loop(
-        sink,
-        stream,
-        shutdown.clone(),
-        http,
-        register.local_url.to_string(),
-        ack.service_token.clone(),
-        register.internal_secret.map(str::to_string),
-    ));
+    // Built once per connection and shared via `Arc`: `local_url`,
+    // `service_token`, and `internal_secret` are invariant for the whole
+    // tunnel's lifetime, so every spawned relay task should bump a refcount
+    // rather than re-allocating its own copy of these strings.
+    let ctx = Arc::new(RelayCtx {
+        local_url: register.local_url.to_string(),
+        service_token: ack.service_token.clone(),
+        internal_secret: register.internal_secret.map(str::to_string),
+    });
+    tokio::spawn(run_tunnel_loop(sink, stream, shutdown.clone(), http, ctx));
 
     Ok(TunnelHandle {
         session_id: ack.session_id,
@@ -434,6 +436,17 @@ async fn await_register_ack(
     }
 }
 
+/// Connection-invariant values every relayed request needs: the local
+/// module's base URL and the CLI-minted auth its Internal scope requires.
+/// Built once per tunnel connection ([`open`]) and shared via `Arc` so each
+/// spawned relay task ([`spawn_rpc_relay_if_req`]) clones a cheap refcount
+/// instead of re-allocating these strings on every inbound `rpc.req`.
+struct RelayCtx {
+    local_url: String,
+    service_token: String,
+    internal_secret: Option<String>,
+}
+
 /// Long-running tunnel loop: ping every 30s, respond to server pings,
 /// shut down on signal. Surfaces transport failures via `warn_prefix()`
 /// so a silently-dying tunnel doesn't leave the user wondering why
@@ -444,9 +457,7 @@ async fn run_tunnel_loop(
     mut stream: WsReader,
     shutdown: Arc<Notify>,
     http: reqwest::Client,
-    local_url: String,
-    service_token: String,
-    internal_secret: Option<String>,
+    ctx: Arc<RelayCtx>,
 ) {
     let mut interval = tokio::time::interval(Duration::from_secs(30));
     // The first tick fires immediately — consume it so the first ping is at
@@ -478,9 +489,9 @@ async fn run_tunnel_loop(
                 // platform, so fetching every beat is cheap and safe.
                 let hash = fetch_manifest_hash(
                     &http,
-                    &local_url,
-                    &service_token,
-                    internal_secret.as_deref(),
+                    &ctx.local_url,
+                    &ctx.service_token,
+                    ctx.internal_secret.as_deref(),
                 )
                 .await;
                 let ping = Frame::new(FrameType::Ping, ping_payload(hash.as_deref()));
@@ -499,25 +510,20 @@ async fn run_tunnel_loop(
             }
             msg = stream.next() => {
                 match msg {
-                    Some(Ok(Message::Text(t))) => {
-                        spawn_rpc_relay_if_req(
-                            &t.to_string(),
-                            &tx,
-                            &http,
-                            &local_url,
-                            &service_token,
-                            &internal_secret,
-                        );
-                    }
-                    Some(Ok(Message::Binary(b))) => {
-                        spawn_rpc_relay_if_req(
-                            &String::from_utf8_lossy(&b),
-                            &tx,
-                            &http,
-                            &local_url,
-                            &service_token,
-                            &internal_secret,
-                        );
+                    // Text and Binary both just carry a JSON frame — extract
+                    // the string once (borrowed where possible; only Binary's
+                    // lossy UTF-8 conversion may allocate) and relay through
+                    // one call, rather than duplicating the relay call per
+                    // variant. `t.to_string()` would force-copy the whole
+                    // frame before we even know it's an `rpc.req` worth
+                    // acting on, so borrow via `as_str()` instead.
+                    Some(Ok(m @ (Message::Text(_) | Message::Binary(_)))) => {
+                        let text: Cow<'_, str> = match &m {
+                            Message::Text(t) => Cow::Borrowed(t.as_str()),
+                            Message::Binary(b) => String::from_utf8_lossy(b),
+                            _ => unreachable!(),
+                        };
+                        spawn_rpc_relay_if_req(&text, &tx, &http, &ctx);
                     }
                     Some(Ok(Message::Ping(p))) => {
                         let _ = sink.send(Message::Pong(p)).await;
@@ -560,9 +566,7 @@ fn spawn_rpc_relay_if_req(
     text: &str,
     tx: &mpsc::UnboundedSender<Message>,
     http: &reqwest::Client,
-    local_url: &str,
-    service_token: &str,
-    internal_secret: &Option<String>,
+    ctx: &Arc<RelayCtx>,
 ) {
     let frame: Frame = match serde_json::from_str(text) {
         Ok(f) => f,
@@ -600,9 +604,7 @@ fn spawn_rpc_relay_if_req(
     tokio::spawn(relay_rpc_req(
         tx.clone(),
         http.clone(),
-        local_url.to_string(),
-        service_token.to_string(),
-        internal_secret.clone(),
+        ctx.clone(),
         frame.id,
         req,
     ));
@@ -613,17 +615,15 @@ fn spawn_rpc_relay_if_req(
 async fn relay_rpc_req(
     tx: mpsc::UnboundedSender<Message>,
     http: reqwest::Client,
-    local_url: String,
-    service_token: String,
-    internal_secret: Option<String>,
+    ctx: Arc<RelayCtx>,
     corr_id: String,
     req: RpcReqPayload,
 ) {
     let mut frame = match relay_rpc_req_inner(
         &http,
-        &local_url,
-        &service_token,
-        internal_secret.as_deref(),
+        &ctx.local_url,
+        &ctx.service_token,
+        ctx.internal_secret.as_deref(),
         &req,
     )
     .await
@@ -639,6 +639,27 @@ async fn relay_rpc_req(
         // shutting down — nothing left to report it to.
         let _ = tx.send(Message::Text(body));
     }
+}
+
+/// Attach the CLI-minted `X-MS-Platform-Token`/`X-MS-Internal-Secret`
+/// headers a module's Internal scope requires. Shared by
+/// [`fetch_manifest_hash`] (heartbeat GET) and [`relay_rpc_req_inner`]
+/// (relayed request) — both need the identical conditional-header logic:
+/// the token header is only sent when non-empty (pre-register-ack calls
+/// have none yet), the secret header only when the module was started
+/// with one.
+fn attach_internal_auth(
+    mut builder: reqwest::RequestBuilder,
+    service_token: &str,
+    internal_secret: Option<&str>,
+) -> reqwest::RequestBuilder {
+    if !service_token.is_empty() {
+        builder = builder.header("X-MS-Platform-Token", service_token);
+    }
+    if let Some(secret) = internal_secret {
+        builder = builder.header("X-MS-Internal-Secret", secret);
+    }
+    builder
 }
 
 /// Perform the actual local HTTP call for [`relay_rpc_req`]. Split out so
@@ -706,12 +727,7 @@ async fn relay_rpc_req_inner(
     // enforces these on every call, dispatch strips them off the original
     // inbound request before building the relay payload, so the CLI is the
     // one place that (re)attaches them.
-    if !service_token.is_empty() {
-        builder = builder.header("X-MS-Platform-Token", service_token);
-    }
-    if let Some(secret) = internal_secret {
-        builder = builder.header("X-MS-Internal-Secret", secret);
-    }
+    builder = attach_internal_auth(builder, service_token, internal_secret);
     if !body_bytes.is_empty() {
         builder = builder.body(body_bytes);
     }
@@ -780,13 +796,11 @@ async fn fetch_manifest_hash(
     service_token: &str,
     internal_secret: Option<&str>,
 ) -> Option<String> {
-    let mut req = client.get(format!("{local_url}{MODULE_MANIFEST_PATH}"));
-    if !service_token.is_empty() {
-        req = req.header("X-MS-Platform-Token", service_token);
-    }
-    if let Some(secret) = internal_secret {
-        req = req.header("X-MS-Internal-Secret", secret);
-    }
+    let req = attach_internal_auth(
+        client.get(format!("{local_url}{MODULE_MANIFEST_PATH}")),
+        service_token,
+        internal_secret,
+    );
     let resp = req.send().await.ok()?;
     let hash = resp
         .headers()
@@ -800,6 +814,31 @@ async fn fetch_manifest_hash(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pull the next message off `rx`, assert it's `Message::Text`, and
+    /// parse it as a [`Frame`]. Shared by the `relay_rpc_req_*` tests below
+    /// — each previously duplicated this same unwrap-then-parse block.
+    async fn recv_frame(rx: &mut mpsc::UnboundedReceiver<Message>) -> Frame {
+        let msg = rx.recv().await.expect("expected a relay reply");
+        let Message::Text(text) = msg else {
+            panic!("expected a text message")
+        };
+        serde_json::from_str(&text).unwrap()
+    }
+
+    /// Build a [`RelayCtx`] for tests — a thin `Arc::new` wrapper so call
+    /// sites read the same as the pre-refactor plain-argument calls.
+    fn test_ctx(
+        local_url: impl Into<String>,
+        service_token: impl Into<String>,
+        internal_secret: Option<&str>,
+    ) -> Arc<RelayCtx> {
+        Arc::new(RelayCtx {
+            local_url: local_url.into(),
+            service_token: service_token.into(),
+            internal_secret: internal_secret.map(str::to_string),
+        })
+    }
 
     #[test]
     fn frame_serialization_round_trip() {
@@ -1029,19 +1068,13 @@ mod tests {
         relay_rpc_req(
             tx,
             reqwest::Client::new(),
-            server.url(),
-            "ptok".to_string(),
-            Some("sec".to_string()),
+            test_ctx(server.url(), "ptok", Some("sec")),
             "frm_corr".to_string(),
             req,
         )
         .await;
 
-        let msg = rx.recv().await.expect("expected a relay reply");
-        let Message::Text(text) = msg else {
-            panic!("expected a text message")
-        };
-        let frame: Frame = serde_json::from_str(&text).unwrap();
+        let frame = recv_frame(&mut rx).await;
         assert_eq!(frame.frame_type, FrameType::RpcResp);
         assert_eq!(frame.corr_id.as_deref(), Some("frm_corr"));
         let payload = frame.payload.unwrap();
@@ -1065,19 +1098,13 @@ mod tests {
         relay_rpc_req(
             tx,
             reqwest::Client::new(),
-            "http://127.0.0.1:1".to_string(),
-            String::new(),
-            None,
+            test_ctx("http://127.0.0.1:1", "", None),
             "frm_corr2".to_string(),
             req,
         )
         .await;
 
-        let msg = rx.recv().await.expect("expected a relay reply");
-        let Message::Text(text) = msg else {
-            panic!("expected a text message")
-        };
-        let frame: Frame = serde_json::from_str(&text).unwrap();
+        let frame = recv_frame(&mut rx).await;
         assert_eq!(frame.frame_type, FrameType::RpcErr);
         assert_eq!(frame.corr_id.as_deref(), Some("frm_corr2"));
         assert_eq!(frame.payload.unwrap()["code"], "local_module_unreachable");
@@ -1110,19 +1137,13 @@ mod tests {
         relay_rpc_req(
             tx,
             reqwest::Client::new(),
-            server.url(),
-            String::new(),
-            None,
+            test_ctx(server.url(), "", None),
             "frm_corr3".to_string(),
             req,
         )
         .await;
 
-        let msg = rx.recv().await.expect("expected a relay reply");
-        let Message::Text(text) = msg else {
-            panic!("expected a text message")
-        };
-        let frame: Frame = serde_json::from_str(&text).unwrap();
+        let frame = recv_frame(&mut rx).await;
         assert_eq!(frame.frame_type, FrameType::RpcErr);
         assert_eq!(frame.payload.unwrap()["code"], "local_body_too_large");
     }
@@ -1153,25 +1174,23 @@ mod tests {
         relay_rpc_req(
             tx,
             reqwest::Client::new(),
-            server.url(),
-            String::new(),
-            None,
+            test_ctx(server.url(), "", None),
             "frm_corr3b".to_string(),
             req,
         )
         .await;
 
-        let msg = rx.recv().await.expect("expected a relay reply");
-        let Message::Text(text) = msg else {
-            panic!("expected a text message")
-        };
+        let frame = recv_frame(&mut rx).await;
+        // Re-encode the parsed frame to check its size: JSON key order may
+        // differ from the bytes actually sent over the channel (serde_json
+        // parses objects into a sorted map), but the byte *count* is
+        // unaffected by key order, so this still pins the same transport-cap
+        // regression guard.
+        let encoded_len = serde_json::to_string(&frame).unwrap().len();
         assert!(
-            text.len() <= MAX_INBOUND_FRAME_BYTES,
-            "encoded rpc.resp frame ({} bytes) exceeds the transport cap ({} bytes)",
-            text.len(),
-            MAX_INBOUND_FRAME_BYTES
+            encoded_len <= MAX_INBOUND_FRAME_BYTES,
+            "encoded rpc.resp frame ({encoded_len} bytes) exceeds the transport cap ({MAX_INBOUND_FRAME_BYTES} bytes)"
         );
-        let frame: Frame = serde_json::from_str(&text).unwrap();
         assert_eq!(frame.frame_type, FrameType::RpcResp);
     }
 
@@ -1212,19 +1231,13 @@ mod tests {
         relay_rpc_req(
             tx,
             reqwest::Client::new(),
-            server.url(),
-            "cli-minted-token".to_string(),
-            Some("cli-minted-secret".to_string()),
+            test_ctx(server.url(), "cli-minted-token", Some("cli-minted-secret")),
             "frm_corr_auth".to_string(),
             req,
         )
         .await;
 
-        let msg = rx.recv().await.expect("expected a relay reply");
-        let Message::Text(text) = msg else {
-            panic!("expected a text message")
-        };
-        let frame: Frame = serde_json::from_str(&text).unwrap();
+        let frame = recv_frame(&mut rx).await;
         // mockito's match_header on both names, with only one value each,
         // asserts the request had exactly the CLI-minted value — if the
         // spoofed value had also been forwarded (appended), the request
@@ -1242,7 +1255,8 @@ mod tests {
         let http = reqwest::Client::new();
         let ping = Frame::new(FrameType::Ping, None);
         let text = serde_json::to_string(&ping).unwrap();
-        spawn_rpc_relay_if_req(&text, &tx, &http, "http://127.0.0.1:1", "", &None);
+        let ctx = test_ctx("http://127.0.0.1:1", "", None);
+        spawn_rpc_relay_if_req(&text, &tx, &http, &ctx);
         assert!(rx.try_recv().is_err());
     }
 }

--- a/src/commands/dev/tunnel.rs
+++ b/src/commands/dev/tunnel.rs
@@ -5,19 +5,26 @@
 //!   - `connect` — open the WSS, send `register`, await `register_ack`, hold the
 //!     connection and ping every 30s until the host process tells us to stop
 //!
-//! Phase 1 ships the connect + register half. RPC frames + SQL frames are
-//! deferred to Phase 2/3 per the design doc; this module's enum
-//! intentionally enumerates them so future PRs only add handler arms.
+//! Phase 1 shipped the connect + register half. Phase 2 (this module) adds
+//! the `rpc.req` handler: the server relays an HTTP request over the WSS
+//! connection when dispatch can't reach the local module directly (real
+//! Lambda/prod, no shared network); the CLI performs that request against
+//! `local_url` and replies with `rpc.resp`/`rpc.err`. SQL frames are still
+//! deferred to Phase 3 per the design doc; this module's enum intentionally
+//! enumerates them so that PR only adds a handler arm.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpStream;
-use tokio::sync::Notify;
+use tokio::sync::{Notify, mpsc};
 use tokio::time::MissedTickBehavior;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
@@ -37,6 +44,19 @@ type WsReader = SplitStream<WsStream>;
 /// exposing a memory-bomb surface to a misbehaving server.
 const MAX_INBOUND_FRAME_BYTES: usize = 1 << 20;
 
+/// Cap on the *raw* local-module response body accepted by
+/// [`relay_rpc_req_inner`]. The body is base64-encoded into `RpcRespPayload`
+/// and then wrapped in a JSON `Frame` before it hits the WSS transport, so
+/// checking `body.len()` against [`MAX_INBOUND_FRAME_BYTES`] directly is
+/// wrong: base64 alone inflates by ~4/3, and the JSON envelope (headers,
+/// frame/corr ids, field names) adds more on top. Scale the raw-body cap
+/// down to 3/4 of the transport ceiling for the base64 expansion, then
+/// reserve another chunk for the envelope, so a body that passes this check
+/// is guaranteed to still fit once encoded and wrapped.
+const RELAY_ENVELOPE_OVERHEAD_BYTES: usize = 8 * 1024;
+const MAX_RELAY_BODY_BYTES: usize =
+    (MAX_INBOUND_FRAME_BYTES / 4) * 3 - RELAY_ENVELOPE_OVERHEAD_BYTES;
+
 /// Local Internal-scope endpoint the SDK serves the module manifest on. The
 /// heartbeat GETs this (through the CLI's own dev proxy) purely to read the
 /// hash response header — it is NOT the platform's `/v1/tunnel/manifest` route.
@@ -55,6 +75,12 @@ const MANIFEST_HASH_HEADER: &str = "X-MS-Manifest-Hash";
 // a mid-restart module refuses the connection and fails fast), so 500ms is a
 // generous ceiling that keeps the beat responsive.
 const MANIFEST_FETCH_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Per-relay-request HTTP timeout against the local module. Set a few
+/// seconds under dispatch's `MS_MODULE_CALL_TIMEOUT` wait (30s default) so
+/// the CLI proactively sends `rpc.err` instead of dispatch always hitting a
+/// blind timeout waiting on the relay correlation list.
+const RELAY_REQUEST_TIMEOUT: Duration = Duration::from_secs(25);
 
 mod uuid_lite {
     //! Tiny v4 UUID generator. We don't pull `uuid` for one call site — the
@@ -174,12 +200,46 @@ pub(super) struct RegisterAck {
     pub expires_at: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct ErrorPayload {
     code: String,
     message: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     slug: Option<String>,
+}
+
+/// `rpc.req` payload — mirrors api-platform's `internal/dispatch/ws/frames.go`
+/// `RPCReqPayload`. Dispatch builds this from the inbound HTTP request (with
+/// `X-MS-*` headers already stripped) when it can't dial the module's
+/// `local_url` directly (real Lambda/prod, no shared network).
+#[derive(Debug, Deserialize)]
+pub(super) struct RpcReqPayload {
+    pub method: String,
+    pub path: String,
+    #[serde(default)]
+    pub query: String,
+    #[serde(default)]
+    pub headers: HashMap<String, Vec<String>>,
+    /// Base64-encoded (`STANDARD` engine — matches Go's `encoding/json`
+    /// `[]byte` convention, not URL-safe) request body. `None` when the
+    /// original request had no body (Go's `omitempty` drops a nil/empty
+    /// slice entirely rather than emitting an empty string).
+    #[serde(default)]
+    pub body: Option<String>,
+}
+
+/// `rpc.resp` payload — mirrors api-platform's `internal/dispatch/ws/frames.go`
+/// `RPCRespPayload`. Sent back on the mpsc channel once the local module
+/// answers the relayed request.
+#[derive(Debug, Serialize)]
+pub(super) struct RpcRespPayload {
+    pub status: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<HashMap<String, Vec<String>>>,
+    /// Base64-encoded (`STANDARD` engine) response body; `None` for an
+    /// empty body, matching the request side's `omitempty` convention.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
 }
 
 /// Typed register-time rejection. Distinguishes the cases the CLI knows
@@ -394,6 +454,11 @@ async fn run_tunnel_loop(
     // (e.g. laptop sleep) doesn't burst-ping on resume.
     interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
     interval.tick().await;
+    // Relay replies (`rpc.resp`/`rpc.err`) funnel back through this channel
+    // rather than being sent directly from the spawned relay task: a
+    // `SplitSink` can't be shared/sent across concurrent tasks, and `sink`
+    // is already owned by this loop for pings/pongs/close.
+    let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
     loop {
         tokio::select! {
             _ = shutdown.notified() => {
@@ -426,11 +491,33 @@ async fn run_tunnel_loop(
                     }
                 }
             }
+            Some(msg) = rx.recv() => {
+                if let Err(e) = sink.send(msg).await {
+                    eprintln!("{} tunnel: relay reply send failed ({e}); closing tunnel", warn_prefix());
+                    return;
+                }
+            }
             msg = stream.next() => {
                 match msg {
-                    Some(Ok(Message::Text(_))) | Some(Ok(Message::Binary(_))) => {
-                        // Server frames (pong, future RPC responses) ignored
-                        // for now — Phase 1 doesn't act on them client-side.
+                    Some(Ok(Message::Text(t))) => {
+                        spawn_rpc_relay_if_req(
+                            &t.to_string(),
+                            &tx,
+                            &http,
+                            &local_url,
+                            &service_token,
+                            &internal_secret,
+                        );
+                    }
+                    Some(Ok(Message::Binary(b))) => {
+                        spawn_rpc_relay_if_req(
+                            &String::from_utf8_lossy(&b),
+                            &tx,
+                            &http,
+                            &local_url,
+                            &service_token,
+                            &internal_secret,
+                        );
                     }
                     Some(Ok(Message::Ping(p))) => {
                         let _ = sink.send(Message::Pong(p)).await;
@@ -460,6 +547,222 @@ async fn run_tunnel_loop(
 /// (the frame's `payload` field stays absent).
 fn ping_payload(hash: Option<&str>) -> Option<serde_json::Value> {
     hash.map(|h| serde_json::json!({ "manifest_hash": h }))
+}
+
+/// Parse one inbound WSS text/binary payload as a [`Frame`] and, if it's an
+/// `rpc.req`, spawn a child task to relay it to the local module and reply
+/// on `tx`. Spawned per-request rather than awaited inline: `select!` fully
+/// drives one ready arm before re-polling, so an inline call here would
+/// block the 30s heartbeat and serialize concurrent asset/API requests
+/// behind it. Any other frame type (register/register_ack only ever arrive
+/// during the handshake; the SQL plane is still deferred) is ignored.
+fn spawn_rpc_relay_if_req(
+    text: &str,
+    tx: &mpsc::UnboundedSender<Message>,
+    http: &reqwest::Client,
+    local_url: &str,
+    service_token: &str,
+    internal_secret: &Option<String>,
+) {
+    let frame: Frame = match serde_json::from_str(text) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!(
+                "{} tunnel: malformed inbound frame ({e}); ignoring",
+                warn_prefix()
+            );
+            return;
+        }
+    };
+    if frame.frame_type != FrameType::RpcReq {
+        // register/register_ack only ever arrive pre-handshake; sql.* is
+        // still deferred to Phase 3; ping/pong/close aren't sent as
+        // Text/Binary. Nothing else to act on client-side yet.
+        return;
+    }
+    let Some(payload) = frame.payload else {
+        eprintln!(
+            "{} tunnel: rpc.req missing payload; ignoring",
+            warn_prefix()
+        );
+        return;
+    };
+    let req: RpcReqPayload = match serde_json::from_value(payload) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!(
+                "{} tunnel: rpc.req malformed payload ({e}); ignoring",
+                warn_prefix()
+            );
+            return;
+        }
+    };
+    tokio::spawn(relay_rpc_req(
+        tx.clone(),
+        http.clone(),
+        local_url.to_string(),
+        service_token.to_string(),
+        internal_secret.clone(),
+        frame.id,
+        req,
+    ));
+}
+
+/// Relay one `rpc.req` to the local module and send `rpc.resp`/`rpc.err`
+/// (correlated on `corr_id`, the original frame's `id`) back on `tx`.
+async fn relay_rpc_req(
+    tx: mpsc::UnboundedSender<Message>,
+    http: reqwest::Client,
+    local_url: String,
+    service_token: String,
+    internal_secret: Option<String>,
+    corr_id: String,
+    req: RpcReqPayload,
+) {
+    let mut frame = match relay_rpc_req_inner(
+        &http,
+        &local_url,
+        &service_token,
+        internal_secret.as_deref(),
+        &req,
+    )
+    .await
+    {
+        Ok(resp) => Frame::new(FrameType::RpcResp, serde_json::to_value(&resp).ok()),
+        Err(err) => Frame::new(FrameType::RpcErr, serde_json::to_value(&err).ok()),
+    };
+    frame.corr_id = Some(corr_id);
+    if let Ok(body) = serde_json::to_string(&frame) {
+        // The receiving end (`rx.recv()` in `run_tunnel_loop`) only goes
+        // away when the loop itself is exiting/exited, so a send failure
+        // here just means we lost the reply to a tunnel that's already
+        // shutting down — nothing left to report it to.
+        let _ = tx.send(Message::Text(body));
+    }
+}
+
+/// Perform the actual local HTTP call for [`relay_rpc_req`]. Split out so
+/// the happy/error paths can be expressed with `?` and converted to a
+/// single `Frame` by the caller.
+async fn relay_rpc_req_inner(
+    http: &reqwest::Client,
+    local_url: &str,
+    service_token: &str,
+    internal_secret: Option<&str>,
+    req: &RpcReqPayload,
+) -> std::result::Result<RpcRespPayload, ErrorPayload> {
+    let body_bytes: Vec<u8> = match &req.body {
+        Some(b64) => STANDARD.decode(b64).map_err(|e| ErrorPayload {
+            code: "local_module_unreachable".to_string(),
+            message: format!("dev: decode relay request body: {e}"),
+            slug: None,
+        })?,
+        None => Vec::new(),
+    };
+
+    let method = req
+        .method
+        .parse::<reqwest::Method>()
+        .map_err(|e| ErrorPayload {
+            code: "local_module_unreachable".to_string(),
+            message: format!("dev: invalid relay method {:?}: {e}", req.method),
+            slug: None,
+        })?;
+
+    // Only append `?query` when a query string is actually present — an
+    // unconditional trailing `?` changes the request target (some servers,
+    // and notably mockito's matcher in tests, don't treat `/big?` as
+    // equivalent to `/big`).
+    let url = if req.query.is_empty() {
+        format!("{local_url}{path}", path = req.path)
+    } else {
+        format!(
+            "{local_url}{path}?{query}",
+            path = req.path,
+            query = req.query
+        )
+    };
+    let mut builder = http.request(method, url).timeout(RELAY_REQUEST_TIMEOUT);
+    for (name, values) in &req.headers {
+        // Defense in depth: dispatch is expected to strip these off the
+        // original inbound request before building the relay payload (see
+        // the precedent in `fetch_manifest_hash`), but `RequestBuilder::header`
+        // *appends* rather than replaces, so trusting that unconditionally
+        // would let a forwarded value for either header land ahead of the
+        // CLI-minted one below — first-value-wins header readers (e.g. Go's
+        // `http.Header.Get`) would then pick the spoofed value over the
+        // authoritative one. Drop any wire-supplied value for these two
+        // names regardless of what dispatch is supposed to have done.
+        if name.eq_ignore_ascii_case("x-ms-platform-token")
+            || name.eq_ignore_ascii_case("x-ms-internal-secret")
+        {
+            continue;
+        }
+        for value in values {
+            builder = builder.header(name.as_str(), value.as_str());
+        }
+    }
+    // Same precedent as `fetch_manifest_hash`: the module's Internal scope
+    // enforces these on every call, dispatch strips them off the original
+    // inbound request before building the relay payload, so the CLI is the
+    // one place that (re)attaches them.
+    if !service_token.is_empty() {
+        builder = builder.header("X-MS-Platform-Token", service_token);
+    }
+    if let Some(secret) = internal_secret {
+        builder = builder.header("X-MS-Internal-Secret", secret);
+    }
+    if !body_bytes.is_empty() {
+        builder = builder.body(body_bytes);
+    }
+
+    let resp = builder.send().await.map_err(|e| ErrorPayload {
+        code: "local_module_unreachable".to_string(),
+        message: format!("dev: local module unreachable: {e}"),
+        slug: None,
+    })?;
+
+    let status = resp.status().as_u16();
+    let mut headers: HashMap<String, Vec<String>> = HashMap::new();
+    for (name, value) in resp.headers() {
+        if let Ok(v) = value.to_str() {
+            headers
+                .entry(name.as_str().to_string())
+                .or_default()
+                .push(v.to_string());
+        }
+    }
+
+    let body = resp.bytes().await.map_err(|e| ErrorPayload {
+        code: "local_module_malformed_response".to_string(),
+        message: format!("dev: read local module response body: {e}"),
+        slug: None,
+    })?;
+
+    // Reject before handing an oversized frame to the WSS transport (whose
+    // own frame-size cap is the same MAX_INBOUND_FRAME_BYTES ceiling) — a
+    // clean rpc.err beats an opaque transport-level send failure. Compare
+    // against MAX_RELAY_BODY_BYTES (not MAX_INBOUND_FRAME_BYTES): the raw
+    // body is base64-encoded and then JSON-wrapped before it reaches the
+    // transport, so gating on the raw length alone would let a body through
+    // that's actually oversized once encoded.
+    if body.len() > MAX_RELAY_BODY_BYTES {
+        return Err(ErrorPayload {
+            code: "local_body_too_large".to_string(),
+            message: format!(
+                "dev: local module response body ({} bytes) exceeds the {} byte relay cap",
+                body.len(),
+                MAX_RELAY_BODY_BYTES
+            ),
+            slug: None,
+        });
+    }
+
+    Ok(RpcRespPayload {
+        status,
+        headers: (!headers.is_empty()).then_some(headers),
+        body: (!body.is_empty()).then(|| STANDARD.encode(&body)),
+    })
 }
 
 /// GET the module's local manifest endpoint and return the SDK's
@@ -637,5 +940,309 @@ mod tests {
     #[test]
     fn with_token_param_rejects_malformed_url() {
         assert!(with_token_param("not a url", "ttok").is_err());
+    }
+
+    #[test]
+    fn rpc_req_payload_deserializes_go_json_marshal_fixture() {
+        // Shaped like Go's `json.Marshal(RPCReqPayload{...})` output.
+        let fixture = r#"{"method":"POST","path":"/api/widgets","query":"limit=10","headers":{"Content-Type":["application/json"]},"body":"aGVsbG8="}"#;
+        let payload: RpcReqPayload = serde_json::from_str(fixture).unwrap();
+        assert_eq!(payload.method, "POST");
+        assert_eq!(payload.path, "/api/widgets");
+        assert_eq!(payload.query, "limit=10");
+        assert_eq!(
+            payload.headers.get("Content-Type").unwrap(),
+            &vec!["application/json".to_string()]
+        );
+        let decoded = STANDARD.decode(payload.body.unwrap()).unwrap();
+        assert_eq!(decoded, b"hello");
+    }
+
+    #[test]
+    fn rpc_req_payload_body_uses_standard_base64_not_url_safe() {
+        // 0xFF 0xFF 0xFF encodes to "////" under STANDARD but "____" under
+        // URL_SAFE — pins the engine so a future drift to url-safe breaks
+        // loudly instead of silently mis-decoding relayed request bodies.
+        let fixture = r#"{"method":"POST","path":"/x","body":"////"}"#;
+        let payload: RpcReqPayload = serde_json::from_str(fixture).unwrap();
+        let decoded = STANDARD.decode(payload.body.unwrap()).unwrap();
+        assert_eq!(decoded, vec![0xFF, 0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn rpc_req_payload_omitted_fields_default_empty() {
+        let payload: RpcReqPayload =
+            serde_json::from_str(r#"{"method":"GET","path":"/"}"#).unwrap();
+        assert_eq!(payload.query, "");
+        assert!(payload.headers.is_empty());
+        assert!(payload.body.is_none());
+    }
+
+    #[test]
+    fn rpc_resp_payload_omits_absent_fields() {
+        let payload = RpcRespPayload {
+            status: 204,
+            headers: None,
+            body: None,
+        };
+        let s = serde_json::to_string(&payload).unwrap();
+        assert_eq!(s, r#"{"status":204}"#);
+    }
+
+    #[test]
+    fn rpc_resp_payload_encodes_body_as_standard_base64() {
+        let payload = RpcRespPayload {
+            status: 200,
+            headers: Some(HashMap::from([(
+                "Content-Type".to_string(),
+                vec!["text/plain".to_string()],
+            )])),
+            body: Some(STANDARD.encode(b"hello")),
+        };
+        let s = serde_json::to_string(&payload).unwrap();
+        assert!(s.contains(r#""status":200"#));
+        assert!(s.contains(r#""body":"aGVsbG8=""#));
+    }
+
+    #[tokio::test]
+    async fn relay_rpc_req_success_round_trips_through_channel() {
+        let mut server = mockito::Server::new_async().await;
+        let m = server
+            .mock("GET", "/hello?x=1")
+            .match_header("x-ms-platform-token", "ptok")
+            .match_header("x-ms-internal-secret", "sec")
+            .match_header("x-custom", "abc")
+            .with_status(201)
+            .with_header("content-type", "text/plain")
+            .with_body("hi there")
+            .create_async()
+            .await;
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+        let req = RpcReqPayload {
+            method: "GET".to_string(),
+            path: "/hello".to_string(),
+            query: "x=1".to_string(),
+            headers: HashMap::from([("X-Custom".to_string(), vec!["abc".to_string()])]),
+            body: None,
+        };
+        relay_rpc_req(
+            tx,
+            reqwest::Client::new(),
+            server.url(),
+            "ptok".to_string(),
+            Some("sec".to_string()),
+            "frm_corr".to_string(),
+            req,
+        )
+        .await;
+
+        let msg = rx.recv().await.expect("expected a relay reply");
+        let Message::Text(text) = msg else {
+            panic!("expected a text message")
+        };
+        let frame: Frame = serde_json::from_str(&text).unwrap();
+        assert_eq!(frame.frame_type, FrameType::RpcResp);
+        assert_eq!(frame.corr_id.as_deref(), Some("frm_corr"));
+        let payload = frame.payload.unwrap();
+        assert_eq!(payload["status"], 201);
+        let body_b64 = payload["body"].as_str().unwrap();
+        assert_eq!(STANDARD.decode(body_b64).unwrap(), b"hi there");
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn relay_rpc_req_unreachable_module_sends_rpc_err() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+        let req = RpcReqPayload {
+            method: "GET".to_string(),
+            path: "/x".to_string(),
+            query: String::new(),
+            headers: HashMap::new(),
+            body: None,
+        };
+        // Nothing listening on this port → connect refused.
+        relay_rpc_req(
+            tx,
+            reqwest::Client::new(),
+            "http://127.0.0.1:1".to_string(),
+            String::new(),
+            None,
+            "frm_corr2".to_string(),
+            req,
+        )
+        .await;
+
+        let msg = rx.recv().await.expect("expected a relay reply");
+        let Message::Text(text) = msg else {
+            panic!("expected a text message")
+        };
+        let frame: Frame = serde_json::from_str(&text).unwrap();
+        assert_eq!(frame.frame_type, FrameType::RpcErr);
+        assert_eq!(frame.corr_id.as_deref(), Some("frm_corr2"));
+        assert_eq!(frame.payload.unwrap()["code"], "local_module_unreachable");
+    }
+
+    #[tokio::test]
+    async fn relay_rpc_req_oversized_response_is_rejected() {
+        let mut server = mockito::Server::new_async().await;
+        // One byte over MAX_RELAY_BODY_BYTES (the raw-body cap), not
+        // MAX_INBOUND_FRAME_BYTES (the transport cap) — regression guard
+        // for the base64+JSON-envelope inflation the raw-body cap accounts
+        // for. A body sized to the *transport* cap would base64-inflate to
+        // well past it and should already be rejected here.
+        let big_body = vec![b'a'; MAX_RELAY_BODY_BYTES + 1];
+        let _m = server
+            .mock("GET", "/big")
+            .with_status(200)
+            .with_body(big_body)
+            .create_async()
+            .await;
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+        let req = RpcReqPayload {
+            method: "GET".to_string(),
+            path: "/big".to_string(),
+            query: String::new(),
+            headers: HashMap::new(),
+            body: None,
+        };
+        relay_rpc_req(
+            tx,
+            reqwest::Client::new(),
+            server.url(),
+            String::new(),
+            None,
+            "frm_corr3".to_string(),
+            req,
+        )
+        .await;
+
+        let msg = rx.recv().await.expect("expected a relay reply");
+        let Message::Text(text) = msg else {
+            panic!("expected a text message")
+        };
+        let frame: Frame = serde_json::from_str(&text).unwrap();
+        assert_eq!(frame.frame_type, FrameType::RpcErr);
+        assert_eq!(frame.payload.unwrap()["code"], "local_body_too_large");
+    }
+
+    #[tokio::test]
+    async fn relay_rpc_req_accepted_body_fits_transport_cap_once_encoded() {
+        // Regression guard for the base64/JSON-envelope inflation bug: a
+        // body right at the raw-body cap must still produce an encoded
+        // `rpc.resp` frame that fits under MAX_INBOUND_FRAME_BYTES, the
+        // actual WSS transport ceiling.
+        let mut server = mockito::Server::new_async().await;
+        let body = vec![b'a'; MAX_RELAY_BODY_BYTES];
+        let _m = server
+            .mock("GET", "/big-ok")
+            .with_status(200)
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+        let req = RpcReqPayload {
+            method: "GET".to_string(),
+            path: "/big-ok".to_string(),
+            query: String::new(),
+            headers: HashMap::new(),
+            body: None,
+        };
+        relay_rpc_req(
+            tx,
+            reqwest::Client::new(),
+            server.url(),
+            String::new(),
+            None,
+            "frm_corr3b".to_string(),
+            req,
+        )
+        .await;
+
+        let msg = rx.recv().await.expect("expected a relay reply");
+        let Message::Text(text) = msg else {
+            panic!("expected a text message")
+        };
+        assert!(
+            text.len() <= MAX_INBOUND_FRAME_BYTES,
+            "encoded rpc.resp frame ({} bytes) exceeds the transport cap ({} bytes)",
+            text.len(),
+            MAX_INBOUND_FRAME_BYTES
+        );
+        let frame: Frame = serde_json::from_str(&text).unwrap();
+        assert_eq!(frame.frame_type, FrameType::RpcResp);
+    }
+
+    #[tokio::test]
+    async fn relay_rpc_req_strips_wire_supplied_auth_headers_before_forwarding() {
+        // Regression guard for the header-smuggling finding: if `req.headers`
+        // (server-relayed) already carries X-MS-Platform-Token/
+        // X-MS-Internal-Secret — e.g. a buggy/compromised dispatch that
+        // failed to strip them — the CLI must not forward the wire-supplied
+        // value. Only the CLI-minted value (passed in as `service_token`/
+        // `internal_secret`) should reach the local module.
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/secure")
+            .match_header("x-ms-platform-token", "cli-minted-token")
+            .match_header("x-ms-internal-secret", "cli-minted-secret")
+            .with_status(200)
+            .create_async()
+            .await;
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+        let mut headers = HashMap::new();
+        headers.insert(
+            "X-MS-Platform-Token".to_string(),
+            vec!["spoofed-token".to_string()],
+        );
+        headers.insert(
+            "X-MS-Internal-Secret".to_string(),
+            vec!["spoofed-secret".to_string()],
+        );
+        let req = RpcReqPayload {
+            method: "GET".to_string(),
+            path: "/secure".to_string(),
+            query: String::new(),
+            headers,
+            body: None,
+        };
+        relay_rpc_req(
+            tx,
+            reqwest::Client::new(),
+            server.url(),
+            "cli-minted-token".to_string(),
+            Some("cli-minted-secret".to_string()),
+            "frm_corr_auth".to_string(),
+            req,
+        )
+        .await;
+
+        let msg = rx.recv().await.expect("expected a relay reply");
+        let Message::Text(text) = msg else {
+            panic!("expected a text message")
+        };
+        let frame: Frame = serde_json::from_str(&text).unwrap();
+        // mockito's match_header on both names, with only one value each,
+        // asserts the request had exactly the CLI-minted value — if the
+        // spoofed value had also been forwarded (appended), the request
+        // would carry two values per header and mockito's exact-match
+        // would fail the mock, producing a `local_module_unreachable`
+        // rpc.err below instead of a clean rpc.resp.
+        assert_eq!(frame.frame_type, FrameType::RpcResp);
+    }
+
+    #[test]
+    fn spawn_rpc_relay_if_req_ignores_non_rpc_req_frames() {
+        // Regression guard: a ping/pong/close text frame (or any frame type
+        // other than rpc.req) must not panic or attempt a relay.
+        let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+        let http = reqwest::Client::new();
+        let ping = Frame::new(FrameType::Ping, None);
+        let text = serde_json::to_string(&ping).unwrap();
+        spawn_rpc_relay_if_req(&text, &tx, &http, "http://127.0.0.1:1", "", &None);
+        assert!(rx.try_recv().is_err());
     }
 }


### PR DESCRIPTION
## Summary
- `run_tunnel_loop` gets a 4th `select!` arm (new mpsc channel) to handle inbound `rpc.req` frames: spawns a per-request task that hits the local module over HTTP and replies with `rpc.resp`/`rpc.err`. Spawn-per-request (not inline) so a slow module call doesn't block the 30s heartbeat or serialize concurrent asset/API requests behind it.
- New `RpcReqPayload`/`RpcRespPayload` wire structs, base64 via `base64::engine::general_purpose::STANDARD` (matches Go's default `encoding/json` `[]byte` encoding on the dispatch side — a mismatch here would silently corrupt every relayed body).
- Body-size guard compares against the post-base64+JSON-wrapped size (`MAX_RELAY_BODY_BYTES`, scaled for base64's 4/3 inflation + envelope margin), not the raw response length — a raw-only check would let an already-oversized-once-encoded frame through to the transport.
- Header forwarding strips any wire-supplied `X-MS-Platform-Token`/`X-MS-Internal-Secret` before re-attaching the CLI-minted values — defense in depth against `reqwest::RequestBuilder::header`'s append (not replace) semantics, in case a buggy/compromised dispatch ever forwards those names.

## Coupling
Part of a 3-repo coupled feature — useless independently:
- `api-platform` https://github.com/mirrorstack-ai/api-platform/pull/352 (dispatch-side relay + Redis correlation)
- `mirrorstack-infra` https://github.com/mirrorstack-ai/mirrorstack-infra/pull/85 (`execute-api:ManageConnections` IAM grant)

**Order-independent to merge/deploy** — dispatch only sends `rpc.req` to sessions reporting a version at or above its configured minimum, so an unpatched dispatch never triggers this code path regardless of merge order.

## Test plan
- [x] `cargo build`, `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (197 passed) all green, verified independently
- [x] Adversarial review (2 independent passes, both caught the same 2 issues) → fixed: header-smuggling via append semantics (security), and the size guard checking raw body length instead of the post-encoding size
- [x] New regression tests: header-strip-before-forward (mockito `match_header` asserts exactly one CLI-minted value reaches the module), boundary-body-fits-transport-cap-once-encoded, oversized-response-rejected
- [ ] Real-prod verification (post-merge, paired with the api-platform PR): `mirrorstack dev --tunnel` against real prod, confirm concurrent requests resolve in parallel and heartbeat continues during a relay burst

🤖 Generated with [Claude Code](https://claude.com/claude-code)