### PR TITLE
chore: bump CLI to 0.2.0 to clear the tunnel-relay version gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "mirrorstack"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirrorstack"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Official command-line tool for the MirrorStack platform"


### PR DESCRIPTION
## Summary
- `api-platform`'s dispatch (https://github.com/mirrorstack-ai/api-platform/pull/352, merged) gates the WSS HTTP-relay data plane on `sess.Version >= "0.2.0"` (`minRelayCLIVersion`), but the CLI-side relay PR (#50, merged) never bumped `Cargo.toml`'s own version — every build still reports `0.1.0`.
- Found while attempting a real-prod end-to-end verification of the relay: the gate's plain string comparison rejects `"0.1.0" < "0.2.0"`, so every currently-buildable CLI silently falls back to the old fast-fail 502 path regardless of the relay code being deployed and live.

## Test plan
- [x] `cargo build`, `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (197 passed) all green
- [ ] Real-prod verification (in progress): register a throwaway test module, run `mirrorstack dev --tunnel` built from this branch against prod, confirm the relay actually activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)