### PR TITLE
chore: group per-module dev-tunnel platform-token files under .secret/

### DIFF
--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -18,7 +18,7 @@
 //! Tunnel mode exposes modules to remote callers (via dispatch's Leaf-1
 //! 307), so each module MUST enforce Internal-scope auth rather than
 //! bypass it. Two cooperating mechanisms make that happen:
-//!   - Per-module `.ms-platform-token-<slug>` files carry the
+//!   - Per-module `.secret/ms-platform-token-<slug>` files carry the
 //!     dispatch-minted `stk_*` service token from each tunnel's register
 //!     ack. The runner points each module's MS_PLATFORM_TOKEN_FILE at its
 //!     own file (see docs/platform-module-auth.md). This is the primary
@@ -103,11 +103,11 @@ const PROXY_PORT_DEFAULT: u16 = 8080;
 const MODULE_ROUTE_PREFIX: &str = "/_m/";
 
 /// Per-module platform-token file. The name is a host↔container contract:
-/// the outer run writes it next to go.work, and the inner runner points
-/// each module's MS_PLATFORM_TOKEN_FILE at it through the `.:/modules`
-/// bind mount.
+/// the outer run writes it into `.secret/` next to go.work, and the inner
+/// runner points each module's MS_PLATFORM_TOKEN_FILE at it through the
+/// `.:/modules` bind mount.
 fn platform_token_file(root: &Path, slug: &str) -> PathBuf {
-    root.join(format!(".ms-platform-token-{slug}"))
+    root.join(".secret").join(format!("ms-platform-token-{slug}"))
 }
 
 /// How often the supervisor polls module sources for changes — matches the
@@ -187,9 +187,9 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
     // (only the first module's token), which authenticated whichever module
     // registered first and 401'd every other module on every
     // platform-initiated call (lifecycle install, manifest read, dev-tunnel
-    // API). The files land in `root` and reach the runner through the
-    // `.:/modules` bind mount; the inner runner (`run_inner`) points each
-    // module's MS_PLATFORM_TOKEN_FILE at `.ms-platform-token-<slug>`.
+    // API). The files land in `root/.secret/` and reach the runner through
+    // the `.:/modules` bind mount; the inner runner (`run_inner`) points
+    // each module's MS_PLATFORM_TOKEN_FILE at `.secret/ms-platform-token-<slug>`.
     let mut token_files: Vec<PathBuf> = Vec::new();
 
     // Per-session MS_INTERNAL_SECRET. Sent on each register frame (so
@@ -210,6 +210,8 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
             .as_deref()
             .expect("tunnel mode mints a secret");
         let state = open_tunnels(root, &ready, args.local_url.as_deref(), secret)?;
+        std::fs::create_dir_all(root.join(".secret"))
+            .context("dev: create .secret directory for platform token files")?;
         // `open_tunnels` pushes handles in `ready` order, so zip is aligned.
         for (m, handle) in ready.iter().zip(state.0.iter()) {
             let slug = m.dir.file_name().unwrap().to_string_lossy();
@@ -238,7 +240,7 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
         .stderr(Stdio::inherit());
 
     // MS_PLATFORM_TOKEN_FILE is set per-module by the inner runner (each
-    // module reads its own `.ms-platform-token-<slug>`). MS_INTERNAL_SECRET
+    // module reads its own `.secret/ms-platform-token-<slug>`). MS_INTERNAL_SECRET
     // is injected once on the compose env; the runner forwards it to every
     // module process as the SDK's legacy InternalAuth fallback.
     if let Some(secret) = &internal_secret {

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -107,7 +107,8 @@ const MODULE_ROUTE_PREFIX: &str = "/_m/";
 /// runner points each module's MS_PLATFORM_TOKEN_FILE at it through the
 /// `.:/modules` bind mount.
 fn platform_token_file(root: &Path, slug: &str) -> PathBuf {
-    root.join(".secret").join(format!("ms-platform-token-{slug}"))
+    root.join(".secret")
+        .join(format!("ms-platform-token-{slug}"))
 }
 
 /// How often the supervisor polls module sources for changes — matches the

--- a/src/commands/dev/tunnel.rs
+++ b/src/commands/dev/tunnel.rs
@@ -192,7 +192,7 @@ pub(super) struct RegisterPayload<'a> {
 pub(super) struct RegisterAck {
     pub session_id: String,
     /// The per-tunnel service token. The dev runner writes it to a
-    /// per-module `.ms-platform-token-<slug>` file so each spawned module
+    /// per-module `.secret/ms-platform-token-<slug>` file so each spawned module
     /// authenticates platform-initiated calls against ITS own session.
     pub service_token: String,
     /// RFC3339 — informational; the L1.5 reconnect contract makes the
@@ -285,7 +285,7 @@ type RegisterResult<T> = std::result::Result<T, RegisterError>;
 ///
 /// `service_token` is the per-tunnel dispatch-minted token from the
 /// register ack. The dev runner writes it to a per-module
-/// `.ms-platform-token-<slug>` file so each spawned module authenticates
+/// `.secret/ms-platform-token-<slug>` file so each spawned module authenticates
 /// platform-initiated calls (lifecycle install, manifest read) against
 /// ITS own session.
 pub(super) struct TunnelHandle {


### PR DESCRIPTION
## Summary
- \`mirrorstack dev --tunnel\` wrote one auth-token file per module directly into the module workspace root as loose dotfiles (\`.ms-platform-token-oauth-core\`, \`.ms-platform-token-oauth-google\`, ...) — necessary (each live tunnel session gets its own dispatch-minted token; a shared file previously caused every module but the first to 401, see the comment history in \`run_outer\`), but cluttering the directory and needing an ad-hoc gitignore entry per module/naming scheme.
- Groups them under \`.secret/ms-platform-token-<slug>\` instead — one \`.gitignore\` line (\`.secret/\`) covers this and any future per-module secret file.
- \`platform_token_file()\` is the single shared helper both the write side (\`run_outer\`) and read side (\`run_inner\`) call, so this is effectively a one-function change; added \`create_dir_all\` for the new subdirectory on the write side (\`std::fs::write\` doesn't create parent dirs).

Companion PR in ms-app-modules updates \`scripts/dev-runner.sh\`'s independent hardcoded read path to match (it doesn't go through this crate's \`platform_token_file()\` — a separate shell script reading the same file via the container's bind mount).

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo test\` — 213 passed
- [ ] Ship alongside the ms-app-modules companion PR (both must land together — a mismatched path on either side makes every module fail closed)