### PR TITLE
fix(dev): write per-module platform-token files under .secret/

### DIFF
--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -18,7 +18,7 @@
 //! Tunnel mode exposes modules to remote callers (via dispatch's Leaf-1
 //! 307), so each module MUST enforce Internal-scope auth rather than
 //! bypass it. Two cooperating mechanisms make that happen:
-//!   - Per-module `.ms-platform-token-<slug>` files carry the
+//!   - Per-module `.secret/<slug>` files carry the
 //!     dispatch-minted `stk_*` service token from each tunnel's register
 //!     ack. The runner points each module's MS_PLATFORM_TOKEN_FILE at its
 //!     own file (see docs/platform-module-auth.md). This is the primary
@@ -103,11 +103,11 @@ const PROXY_PORT_DEFAULT: u16 = 8080;
 const MODULE_ROUTE_PREFIX: &str = "/_m/";
 
 /// Per-module platform-token file. The name is a host↔container contract:
-/// the outer run writes it next to go.work, and the inner runner points
-/// each module's MS_PLATFORM_TOKEN_FILE at it through the `.:/modules`
-/// bind mount.
+/// the outer run writes it into `.secret/` next to go.work, and the inner
+/// runner points each module's MS_PLATFORM_TOKEN_FILE at it through the
+/// `.:/modules` bind mount.
 fn platform_token_file(root: &Path, slug: &str) -> PathBuf {
-    root.join(format!(".ms-platform-token-{slug}"))
+    root.join(".secret").join(slug)
 }
 
 /// How often the supervisor polls module sources for changes — matches the
@@ -187,9 +187,9 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
     // (only the first module's token), which authenticated whichever module
     // registered first and 401'd every other module on every
     // platform-initiated call (lifecycle install, manifest read, dev-tunnel
-    // API). The files land in `root` and reach the runner through the
-    // `.:/modules` bind mount; the inner runner (`run_inner`) points each
-    // module's MS_PLATFORM_TOKEN_FILE at `.ms-platform-token-<slug>`.
+    // API). The files land in `root/.secret/` and reach the runner through
+    // the `.:/modules` bind mount; the inner runner (`run_inner`) points
+    // each module's MS_PLATFORM_TOKEN_FILE at `.secret/<slug>`.
     let mut token_files: Vec<PathBuf> = Vec::new();
 
     // Per-session MS_INTERNAL_SECRET. Sent on each register frame (so
@@ -210,6 +210,8 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
             .as_deref()
             .expect("tunnel mode mints a secret");
         let state = open_tunnels(root, &ready, args.local_url.as_deref(), secret)?;
+        std::fs::create_dir_all(root.join(".secret"))
+            .context("dev: create .secret directory for platform token files")?;
         // `open_tunnels` pushes handles in `ready` order, so zip is aligned.
         for (m, handle) in ready.iter().zip(state.0.iter()) {
             let slug = m.dir.file_name().unwrap().to_string_lossy();
@@ -238,7 +240,7 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
         .stderr(Stdio::inherit());
 
     // MS_PLATFORM_TOKEN_FILE is set per-module by the inner runner (each
-    // module reads its own `.ms-platform-token-<slug>`). MS_INTERNAL_SECRET
+    // module reads its own `.secret/<slug>`). MS_INTERNAL_SECRET
     // is injected once on the compose env; the runner forwards it to every
     // module process as the SDK's legacy InternalAuth fallback.
     if let Some(secret) = &internal_secret {

--- a/src/commands/dev/tunnel.rs
+++ b/src/commands/dev/tunnel.rs
@@ -192,7 +192,7 @@ pub(super) struct RegisterPayload<'a> {
 pub(super) struct RegisterAck {
     pub session_id: String,
     /// The per-tunnel service token. The dev runner writes it to a
-    /// per-module `.ms-platform-token-<slug>` file so each spawned module
+    /// per-module `.secret/<slug>` file so each spawned module
     /// authenticates platform-initiated calls against ITS own session.
     pub service_token: String,
     /// RFC3339 — informational; the L1.5 reconnect contract makes the
@@ -285,7 +285,7 @@ type RegisterResult<T> = std::result::Result<T, RegisterError>;
 ///
 /// `service_token` is the per-tunnel dispatch-minted token from the
 /// register ack. The dev runner writes it to a per-module
-/// `.ms-platform-token-<slug>` file so each spawned module authenticates
+/// `.secret/<slug>` file so each spawned module authenticates
 /// platform-initiated calls (lifecycle install, manifest read) against
 /// ITS own session.
 pub(super) struct TunnelHandle {


### PR DESCRIPTION
## Summary
- Moves the dev-tunnel platform-token files from `.ms-platform-token-<slug>` (loose in the workspace root) to `.secret/<slug>` — a dedicated directory that's easier to gitignore wholesale and keeps sensitive token material visually separated from the rest of the workspace.
- Extracted from a long-lived local worktree during a worktree cleanup pass, rebased onto current `main` (`open_tunnels` gained a `root` parameter upstream since this was first written).

## Test plan
- [x] `cargo build`, `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` all clean
- [x] `cargo test` — 213 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)