### PR TITLE
feat: --share uploads dev-tunnel web bundles to the CDN

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -751,6 +751,120 @@ pub fn activate_app_stage(
     Err(envelope_error(resp))
 }
 
+/// Body for `POST /v1/modules/{moduleId}/dev-bundle/presign` — declares the
+/// bundle the CLI is about to upload. The platform derives the S3 key
+/// server-side from `(moduleId, ownerUserID, sha256)`; the CLI never picks
+/// the key. `content_type` is always `application/javascript` and
+/// `size_bytes` is the raw bundle length (server caps it at 32 MiB).
+#[derive(Debug, Serialize)]
+pub struct DevBundlePresignInput<'a> {
+    pub content_type: &'a str,
+    pub size_bytes: u64,
+    /// Lowercase hex SHA-256 of the bundle bytes (64 chars).
+    pub sha256: &'a str,
+}
+
+/// Response from the dev-bundle presign step: a short-lived presigned S3 PUT
+/// plus the server-derived key the CLI echoes back on confirm.
+#[derive(Debug, Deserialize)]
+pub struct DevBundlePresign {
+    pub upload_url: String,
+    pub key: String,
+    /// RFC3339 presign expiry — informational only (the PUT follows
+    /// immediately, so the CLI never acts on it).
+    #[allow(dead_code)]
+    pub expires_at: String,
+}
+
+/// POST /v1/modules/{moduleId}/dev-bundle/presign — mint a presigned S3 PUT
+/// for a dev-tunnel web bundle (opt-in `--share`). Owner-gated: a module the
+/// caller doesn't own (or an unknown/non-UUID id) collapses to 404
+/// `not_found`. `415` rejects a non-`application/javascript` content type;
+/// `413` rejects an oversize (>32 MiB) declaration; `422` rejects an
+/// ill-formed sha256 — all surfaced as `ApiError::Server` so the caller can
+/// log the specific reason.
+pub fn presign_dev_bundle(
+    http: &Client,
+    apps_base: &str,
+    access_token: &str,
+    module_id: &str,
+    input: &DevBundlePresignInput,
+) -> Result<DevBundlePresign, ApiError> {
+    let endpoint = format!(
+        "{}/v1/modules/{}/dev-bundle/presign",
+        apps_base.trim_end_matches('/'),
+        module_id
+    );
+
+    let resp = http
+        .post(&endpoint)
+        .bearer_auth(access_token)
+        .header("Accept", "application/json")
+        .json(input)
+        .send()?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp.json::<DevBundlePresign>()?);
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(ApiError::Unauthenticated);
+    }
+    Err(envelope_error(resp))
+}
+
+/// Body for `POST /v1/modules/{moduleId}/dev-bundle/confirm` — the key the
+/// presign step returned. The platform HEAD-verifies the uploaded object,
+/// records the CDN URL as the live tunnel session's dev-bundle pointer, and
+/// returns that URL.
+#[derive(Debug, Serialize)]
+pub struct DevBundleConfirmInput<'a> {
+    pub key: &'a str,
+}
+
+/// Response from the dev-bundle confirm step: the CDN URL now served as the
+/// module's `bundleUrl` for the live dev tunnel.
+#[derive(Debug, Deserialize)]
+pub struct DevBundleConfirmed {
+    pub url: String,
+}
+
+/// POST /v1/modules/{moduleId}/dev-bundle/confirm — finalize a dev-bundle
+/// upload. The platform HEAD-verifies the object (content-type,
+/// size ≤ 32 MiB, declared sha256) and points the live tunnel session at the
+/// resulting CDN URL. `403` (IDOR: key outside the caller's own prefix),
+/// `410` (upload missing), and `422` (`confirm_mismatch`) come back as
+/// `ApiError::Server`.
+pub fn confirm_dev_bundle(
+    http: &Client,
+    apps_base: &str,
+    access_token: &str,
+    module_id: &str,
+    key: &str,
+) -> Result<DevBundleConfirmed, ApiError> {
+    let endpoint = format!(
+        "{}/v1/modules/{}/dev-bundle/confirm",
+        apps_base.trim_end_matches('/'),
+        module_id
+    );
+
+    let resp = http
+        .post(&endpoint)
+        .bearer_auth(access_token)
+        .header("Accept", "application/json")
+        .json(&DevBundleConfirmInput { key })
+        .send()?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp.json::<DevBundleConfirmed>()?);
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(ApiError::Unauthenticated);
+    }
+    Err(envelope_error(resp))
+}
+
 /// Body of a successful `POST /v1/auth/sessions/refresh`. The platform
 /// rotates the refresh token on every refresh (replay defense), so we
 /// must persist the new one back to credentials. expires_at is RFC3339
@@ -1898,6 +2012,206 @@ mod tests {
             ApiError::Server { status, code, .. } => {
                 assert_eq!(status, 409);
                 assert_eq!(code, "deploy_not_ready");
+            }
+            other => panic!("expected Server, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn presign_dev_bundle_success_sends_declaration() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/modules/mod-uuid/dev-bundle/presign")
+            .match_header("authorization", "Bearer AT")
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"content_type":"application/javascript","size_bytes":422,"sha256":"abc123"}"#
+                    .into(),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "upload_url": "https://s3.example/put?sig=1",
+                    "key": "modules/mod-uuid/dev/u-1/abc123/web/index.js",
+                    "expires_at": "2026-07-14T00:15:00Z"
+                })
+                .to_string(),
+            )
+            .create();
+
+        let p = presign_dev_bundle(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "mod-uuid",
+            &DevBundlePresignInput {
+                content_type: "application/javascript",
+                size_bytes: 422,
+                sha256: "abc123",
+            },
+        )
+        .expect("ok");
+        assert_eq!(p.upload_url, "https://s3.example/put?sig=1");
+        assert_eq!(p.key, "modules/mod-uuid/dev/u-1/abc123/web/index.js");
+    }
+
+    #[test]
+    fn presign_dev_bundle_413_oversize_surfaces_code() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/modules/mod-uuid/dev-bundle/presign")
+            .with_status(413)
+            .with_body(r#"{"error":{"code":"bundle_too_large","message":"bundle exceeds 32 MiB"}}"#)
+            .create();
+
+        let err = presign_dev_bundle(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "mod-uuid",
+            &DevBundlePresignInput {
+                content_type: "application/javascript",
+                size_bytes: 99,
+                sha256: "abc123",
+            },
+        )
+        .unwrap_err();
+        match err {
+            ApiError::Server { status, code, .. } => {
+                assert_eq!(status, 413);
+                assert_eq!(code, "bundle_too_large");
+            }
+            other => panic!("expected Server, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn presign_dev_bundle_404_not_owner_surfaces_code() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/modules/mod-uuid/dev-bundle/presign")
+            .with_status(404)
+            .with_body(r#"{"error":{"code":"not_found","message":"module not found"}}"#)
+            .create();
+
+        let err = presign_dev_bundle(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "mod-uuid",
+            &DevBundlePresignInput {
+                content_type: "application/javascript",
+                size_bytes: 1,
+                sha256: "abc123",
+            },
+        )
+        .unwrap_err();
+        match err {
+            ApiError::Server { status, code, .. } => {
+                assert_eq!(status, 404);
+                assert_eq!(code, "not_found");
+            }
+            other => panic!("expected Server, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn presign_dev_bundle_401_is_unauthenticated() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/modules/mod-uuid/dev-bundle/presign")
+            .with_status(401)
+            .create();
+
+        let err = presign_dev_bundle(
+            &test_client(),
+            &server.url(),
+            "expired",
+            "mod-uuid",
+            &DevBundlePresignInput {
+                content_type: "application/javascript",
+                size_bytes: 1,
+                sha256: "abc123",
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, ApiError::Unauthenticated), "got {err:?}");
+    }
+
+    #[test]
+    fn confirm_dev_bundle_success_returns_cdn_url() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/modules/mod-uuid/dev-bundle/confirm")
+            .match_header("authorization", "Bearer AT")
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"key":"modules/mod-uuid/dev/u-1/abc123/web/index.js"}"#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "url": "https://cdn.mirrorstack.ai/modules/mod-uuid/dev/u-1/abc123/web/index.js"
+                })
+                .to_string(),
+            )
+            .create();
+
+        let c = confirm_dev_bundle(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "mod-uuid",
+            "modules/mod-uuid/dev/u-1/abc123/web/index.js",
+        )
+        .expect("ok");
+        assert_eq!(
+            c.url,
+            "https://cdn.mirrorstack.ai/modules/mod-uuid/dev/u-1/abc123/web/index.js"
+        );
+    }
+
+    #[test]
+    fn confirm_dev_bundle_422_mismatch_surfaces_code() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/modules/mod-uuid/dev-bundle/confirm")
+            .with_status(422)
+            .with_body(
+                r#"{"error":{"code":"confirm_mismatch","message":"object hash does not match declared sha256"}}"#,
+            )
+            .create();
+
+        let err = confirm_dev_bundle(&test_client(), &server.url(), "AT", "mod-uuid", "some/key")
+            .unwrap_err();
+        match err {
+            ApiError::Server { status, code, .. } => {
+                assert_eq!(status, 422);
+                assert_eq!(code, "confirm_mismatch");
+            }
+            other => panic!("expected Server, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn confirm_dev_bundle_403_idor_surfaces_code() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/modules/mod-uuid/dev-bundle/confirm")
+            .with_status(403)
+            .with_body(r#"{"error":{"code":"forbidden","message":"key outside caller prefix"}}"#)
+            .create();
+
+        let err = confirm_dev_bundle(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "mod-uuid",
+            "modules/other/dev/u-2/x/web/index.js",
+        )
+        .unwrap_err();
+        match err {
+            ApiError::Server { status, code, .. } => {
+                assert_eq!(status, 403);
+                assert_eq!(code, "forbidden");
             }
             other => panic!("expected Server, got {other:?}"),
         }

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -47,7 +47,8 @@ use rand::rngs::OsRng;
 use reqwest::blocking::Client;
 
 use super::{
-    DEFAULT_DISPATCH_BASE, ENV_DISPATCH_URL, ok_mark, resolve_base, session_expired, warn_prefix,
+    DEFAULT_APPS_API_BASE, DEFAULT_DISPATCH_BASE, ENV_APPS_API_URL, ENV_DISPATCH_URL, ok_mark,
+    resolve_base, session_expired, warn_prefix,
 };
 use crate::{api, credentials, http};
 
@@ -55,6 +56,7 @@ mod log_shipper;
 pub(crate) mod module_meta;
 mod proxy;
 mod reload;
+mod share;
 mod tunnel;
 mod workspace;
 
@@ -72,6 +74,12 @@ pub struct DevArgs {
     /// Run all registered modules directly (used inside Docker runner).
     #[arg(long)]
     all: bool,
+    /// Publish each module's built web bundle to the CDN so REMOTE viewers of
+    /// a prod dev-tunnel can load it. Only meaningful with --tunnel; in
+    /// local-only mode the bundle already serves from localhost and this has
+    /// no effect (a warning says so). Off by default — today's behavior.
+    #[arg(long)]
+    share: bool,
     /// Watch module sources and rebuild/restart on change (used with
     /// --all). On by default so the compose runner hot-reloads; pass
     /// --watch=false for a one-shot run.
@@ -182,6 +190,17 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
         ));
     }
 
+    // --share only means something for a prod dev-tunnel: a remote viewer
+    // can't reach the dev's localhost, so the bundle must go to the CDN. In
+    // local-only mode the browser IS on the dev's machine and the localhost
+    // bundle serves fine — sharing would be dead work. Warn, don't error.
+    if args.share && !args.tunnel {
+        eprintln!(
+            "{} --share has no effect without --tunnel: local-only dev serves the bundle from localhost.",
+            warn_prefix()
+        );
+    }
+
     // Per-module platform-token files. Each tunnel session gets its OWN
     // dispatch-minted service token, so each module process must read the
     // token for ITS session. The old behavior wrote a single shared file
@@ -232,6 +251,31 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
         None
     };
 
+    // With --share on a live tunnel, spin up the host-side bundle watcher.
+    // It's the only process holding the user access token (credentials.json,
+    // never mounted into the runner) AND able to read each module's built
+    // web/dist/index.js (via the compose bind mount) AND aware of the tunnel
+    // session registration whose bundleUrl the confirm step updates — so the
+    // upload belongs here, not in the container (see share.rs). Best-effort:
+    // a share failure never blocks the tunnel.
+    let share_state = if args.tunnel && args.share {
+        let targets = build_share_targets(root, &ready);
+        if targets.is_empty() {
+            eprintln!(
+                "{} --share: no module ships a web bundle — nothing to share",
+                warn_prefix()
+            );
+            None
+        } else {
+            let apps_base = resolve_base(ENV_APPS_API_URL, DEFAULT_APPS_API_BASE);
+            let stop = Arc::new(AtomicBool::new(false));
+            let handle = share::spawn_watcher(apps_base, targets, stop.clone());
+            Some((stop, handle))
+        }
+    } else {
+        None
+    };
+
     eprintln!("{} starting docker compose…", ok_mark());
     let mut compose = Command::new("docker");
     compose
@@ -254,6 +298,12 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
         }
         _ => anyhow!("dev: docker compose up: {e}"),
     })?;
+
+    // Stop the share watcher and let its current scan drain before we return.
+    if let Some((stop, handle)) = share_state {
+        stop.store(true, Ordering::SeqCst);
+        let _ = handle.join();
+    }
 
     // Cleanup per-module token files.
     for f in &token_files {
@@ -280,6 +330,28 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Build the `--share` watcher's target list from the ready modules: one
+/// entry per web-bundle-shipping module, carrying its slug, catalog id, and
+/// the host path to its built bundle. Modules that ship no web bundle
+/// (`ShareTarget::for_module` returns None) or whose id can't be resolved
+/// (shouldn't happen — `open_tunnels` already resolved every id) are skipped.
+fn build_share_targets(
+    root: &Path,
+    ready: &[workspace::WorkspaceModule],
+) -> Vec<share::ShareTarget> {
+    let mut targets = Vec::new();
+    for m in ready {
+        let slug = m.dir.file_name().unwrap().to_string_lossy().to_string();
+        let Ok(module_id) = module_meta::read_module_id(&m.abs_dir, root) else {
+            continue;
+        };
+        if let Some(t) = share::ShareTarget::for_module(&m.abs_dir, slug, module_id) {
+            targets.push(t);
+        }
+    }
+    targets
 }
 
 // ── Inner mode: inside Docker, run modules directly ─────────────────

--- a/src/commands/dev/share.rs
+++ b/src/commands/dev/share.rs
@@ -1,0 +1,563 @@
+//! `--share`: publish each tunneled module's built web bundle to the CDN so
+//! REMOTE viewers of a prod dev-tunnel (`mirrorstack dev --tunnel` against
+//! `apps.mirrorstack.ai`) can load it.
+//!
+//! Why the bundle can't ride the tunnel: the WSS RPC relay is a small-JSON
+//! transport (API Gateway caps one frame at ~128 KB), and a ~422 KB web
+//! bundle overflows it. So `--share` moves the bundle OUT of the relay and
+//! onto the CDN — exactly how deployed modules already serve their bundle —
+//! by uploading the built `web/dist/index.js` via a platform-minted,
+//! owner-scoped presigned S3 PUT, then confirming so the platform points the
+//! live tunnel session's `bundleUrl` at the resulting CDN URL. The relay
+//! keeps carrying only API/data. See
+//! docs-temp/dev-tunnel-bundle-serving/DESIGN.md.
+//!
+//! WHERE this runs: the OUTER host process (see `run_outer`). It's the only
+//! process that has all three inputs the upload needs at once — the user
+//! access token from `credentials.json` (a host file, never mounted into the
+//! `docker compose` runner), the built `web/dist/index.js` (written by the
+//! in-container esbuild watcher but visible on the host through the `.:/modules`
+//! bind mount), and the tunnel session registration whose `bundleUrl` the
+//! confirm step updates.
+//!
+//! WHEN: on tunnel start (after the first clean build produces the bundle)
+//! and on each rebuild whose bytes hash differently. There is no clean
+//! cross-process rebuild signal on the host (esbuild's `onEnd`/SSE beat lives
+//! in the container), so the host polls each bundle's content, gated by a
+//! per-module SHA-256 so an unchanged rebuild is a no-op.
+//!
+//! Best-effort: any failure logs a scoped warning and the watcher keeps
+//! serving — a share hiccup must never crash the tunnel or block the module,
+//! mirroring the tunnel's don't-teardown ethos (#58).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use console::style;
+use reqwest::blocking::Client;
+use sha2::{Digest, Sha256};
+
+use super::{ok_mark, warn_prefix};
+use crate::api::{self, ApiError, DevBundlePresignInput};
+use crate::credentials::{self, Credentials};
+use crate::http;
+
+/// Built web bundle path, relative to a module's directory. A module has a
+/// web bundle iff it ships `web/esbuild.config.mjs` (the same gate the web
+/// watcher uses); esbuild writes the bundle here.
+const WEB_BUNDLE_REL: &str = "web/dist/index.js";
+
+/// Content-Type the presigned PUT is signed with and the server pins on the
+/// object. ESM bundles must serve as JavaScript for the browser `import()`.
+const BUNDLE_CONTENT_TYPE: &str = "application/javascript";
+
+/// Client-side mirror of the publisher's `maxModuleBundleBytes` (32 MiB). A
+/// bundle this large is almost certainly a build mistake; reject locally so
+/// we never spend an upload just to collect a 413 at confirm.
+const MAX_BUNDLE_BYTES: u64 = 32 << 20;
+
+/// How often the host re-checks each bundle's content. Matches the Go
+/// supervisor's rebuild poll — fast enough that edit→see stays snappy,
+/// slow enough to stay off the CPU.
+const SCAN_INTERVAL: Duration = Duration::from_millis(2000);
+/// Stop-flag / cadence tick — bounds shutdown latency without busy-looping.
+const TICK: Duration = Duration::from_millis(200);
+
+/// Longer timeout for the raw S3 PUT than the 15s JSON API calls use: a
+/// bundle body is far larger than an API payload and a slow uplink shouldn't
+/// abort it. Matches the deploy path's upload-sized client.
+const UPLOAD_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// One tunneled module the watcher shares. `dist` is the absolute path to
+/// the built bundle on the host (bind-mount view of the container's output);
+/// `module_id` is the catalog id the tunnel registered under (same value
+/// `module_meta::read_module_id` resolves), which the presign/confirm
+/// endpoints key on.
+pub(super) struct ShareTarget {
+    pub slug: String,
+    pub module_id: String,
+    pub dist: PathBuf,
+}
+
+impl ShareTarget {
+    /// Build a target for a module rooted at `module_dir`. Returns `None`
+    /// when the module has no web bundle to share (no `web/esbuild.config.mjs`),
+    /// so pure-backend modules are silently skipped.
+    pub(super) fn for_module(module_dir: &Path, slug: String, module_id: String) -> Option<Self> {
+        if !module_dir.join("web/esbuild.config.mjs").exists() {
+            return None;
+        }
+        Some(Self {
+            slug,
+            module_id,
+            dist: module_dir.join(WEB_BUNDLE_REL),
+        })
+    }
+}
+
+/// Lowercase hex SHA-256 of `bytes`. The content address that both gates
+/// re-uploads (unchanged bytes → same hash → skip) and, server-side, becomes
+/// the CDN key segment.
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+/// Per-module upload flow: presign → PUT → confirm. Returns the confirmed CDN
+/// URL on success. `sha256` is precomputed by the caller (it's also the
+/// hash-gate key) and declared to presign; the raw bytes go to the presigned
+/// S3 URL with the JavaScript content type (no auth header — the URL's
+/// signature IS the auth), then confirm hands back the live `bundleUrl`.
+fn upload_bundle(
+    api_client: &Client,
+    upload_client: &Client,
+    apps_base: &str,
+    creds: &mut Credentials,
+    module_id: &str,
+    bytes: &[u8],
+    sha256: &str,
+) -> Result<String, ApiError> {
+    let presign = credentials::with_refresh_retry(creds, |tok| {
+        api::presign_dev_bundle(
+            api_client,
+            apps_base,
+            tok,
+            module_id,
+            &DevBundlePresignInput {
+                content_type: BUNDLE_CONTENT_TYPE,
+                size_bytes: bytes.len() as u64,
+                sha256,
+            },
+        )
+    })?;
+
+    put_bundle(upload_client, &presign.upload_url, bytes)?;
+
+    let confirmed = credentials::with_refresh_retry(creds, |tok| {
+        api::confirm_dev_bundle(api_client, apps_base, tok, module_id, &presign.key)
+    })?;
+    Ok(confirmed.url)
+}
+
+/// PUT the bundle bytes to the presigned S3 URL with the pinned content type.
+/// A non-2xx is surfaced as `ApiError::Unexpected` (with the S3 body) so the
+/// watcher logs it and retries on the next tick.
+fn put_bundle(upload_client: &Client, url: &str, bytes: &[u8]) -> Result<(), ApiError> {
+    let resp = upload_client
+        .put(url)
+        .header("Content-Type", BUNDLE_CONTENT_TYPE)
+        .body(bytes.to_vec())
+        .send()?;
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    let body = http::read_capped(resp).unwrap_or_default();
+    Err(ApiError::Unexpected {
+        status: status.as_u16(),
+        body: format!(
+            "presigned PUT failed: {}",
+            String::from_utf8_lossy(&body).trim()
+        ),
+    })
+}
+
+/// Mutable per-target bookkeeping: the hash we last confirmed live, and the
+/// hash we last warned about (so a persistently-failing upload doesn't spam
+/// an identical warning every tick).
+struct TargetState {
+    last_uploaded: Option<String>,
+    last_warned: Option<String>,
+}
+
+/// Spawn the host-side share watcher. Owns its own credentials (loaded fresh
+/// so it picks up any refresh the tunnel mint just rotated) and polls each
+/// target's bundle, uploading on first appearance and on every changed hash
+/// until `stop` is set. Returns the join handle so `run_outer` can join it on
+/// teardown. Never returns an error to the caller: a setup failure disables
+/// sharing with a warning rather than failing the whole `dev` session.
+pub(super) fn spawn_watcher(
+    apps_base: String,
+    targets: Vec<ShareTarget>,
+    stop: Arc<AtomicBool>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || run_watcher(&apps_base, &targets, &stop))
+}
+
+fn run_watcher(apps_base: &str, targets: &[ShareTarget], stop: &AtomicBool) {
+    if targets.is_empty() {
+        return;
+    }
+
+    // The watcher outlives a 15-minute access token, so it owns a mutable
+    // credentials copy and refreshes via `with_refresh_retry` per upload. A
+    // failure to even load credentials means we can't share at all — warn and
+    // bow out, leaving the tunnel (which already registered) untouched.
+    let mut creds = match credentials::load_or_login_hint() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "{} --share disabled: {e:#}. Bundles keep serving over the tunnel relay.",
+                warn_prefix()
+            );
+            return;
+        }
+    };
+
+    let api_client = match http::client(Duration::from_secs(15)) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("{} --share disabled: build HTTP client: {e}", warn_prefix());
+            return;
+        }
+    };
+    let upload_client = match http::client(UPLOAD_TIMEOUT) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "{} --share disabled: build upload client: {e}",
+                warn_prefix()
+            );
+            return;
+        }
+    };
+
+    let mut states: Vec<TargetState> = targets
+        .iter()
+        .map(|_| TargetState {
+            last_uploaded: None,
+            last_warned: None,
+        })
+        .collect();
+
+    eprintln!(
+        "{} sharing {} web {} to the CDN on change",
+        ok_mark(),
+        targets.len(),
+        if targets.len() == 1 {
+            "bundle"
+        } else {
+            "bundles"
+        }
+    );
+
+    // Scan immediately so the first clean build is shared the moment it lands,
+    // not one full interval later.
+    let mut last_scan = Instant::now() - SCAN_INTERVAL;
+    while !stop.load(Ordering::SeqCst) {
+        if last_scan.elapsed() >= SCAN_INTERVAL {
+            last_scan = Instant::now();
+            for (target, state) in targets.iter().zip(states.iter_mut()) {
+                share_once(
+                    &api_client,
+                    &upload_client,
+                    apps_base,
+                    &mut creds,
+                    target,
+                    state,
+                );
+            }
+        }
+        thread::sleep(TICK);
+    }
+}
+
+/// One scan pass for one target: read the built bundle, hash-gate it, and
+/// upload if the content changed since the last confirmed upload. Every
+/// failure is a scoped warning + continue — never a panic or early return
+/// that would stall the other targets.
+fn share_once(
+    api_client: &Client,
+    upload_client: &Client,
+    apps_base: &str,
+    creds: &mut Credentials,
+    target: &ShareTarget,
+    state: &mut TargetState,
+) {
+    // No bundle yet (build hasn't produced it) → nothing to do this tick.
+    let bytes = match std::fs::read(&target.dist) {
+        Ok(b) => b,
+        Err(_) => return,
+    };
+
+    if bytes.len() as u64 > MAX_BUNDLE_BYTES {
+        // Warn once per oversize state, not every tick.
+        if state.last_warned.as_deref() != Some("__oversize__") {
+            eprintln!(
+                "{} [{}] web bundle is {} bytes (over the {} MiB share cap) — not sharing",
+                warn_prefix(),
+                target.slug,
+                bytes.len(),
+                MAX_BUNDLE_BYTES >> 20
+            );
+            state.last_warned = Some("__oversize__".to_string());
+        }
+        return;
+    }
+
+    let hash = sha256_hex(&bytes);
+    // Unchanged since the last confirmed upload → no-op (the common
+    // no-op-save case stays free).
+    if state.last_uploaded.as_deref() == Some(hash.as_str()) {
+        return;
+    }
+
+    match upload_bundle(
+        api_client,
+        upload_client,
+        apps_base,
+        creds,
+        &target.module_id,
+        &bytes,
+        &hash,
+    ) {
+        Ok(url) => {
+            state.last_uploaded = Some(hash);
+            state.last_warned = None;
+            eprintln!(
+                "{} [{}] shared web bundle → {}",
+                ok_mark(),
+                style(&target.slug).cyan(),
+                style(url).dim()
+            );
+        }
+        Err(e) => {
+            // Best-effort: keep the tunnel serving. Suppress a repeat warning
+            // for the same still-failing bytes; leaving `last_uploaded`
+            // unchanged means the next tick retries (recovers from a
+            // transient error without needing another edit).
+            if state.last_warned.as_deref() != Some(hash.as_str()) {
+                eprintln!(
+                    "{} [{}] share upload failed ({e}); bundle still serves over the relay, will retry",
+                    warn_prefix(),
+                    target.slug
+                );
+                state.last_warned = Some(hash);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// SHA-256 of "hello" — pins the hex encoding (lowercase, 64 chars).
+    const HELLO_SHA256: &str = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+
+    #[test]
+    fn sha256_hex_is_lowercase_64_hex() {
+        let got = sha256_hex(b"hello");
+        assert_eq!(got, HELLO_SHA256);
+        assert_eq!(got.len(), 64);
+        assert!(
+            got.bytes()
+                .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+        );
+    }
+
+    #[test]
+    fn sha256_hex_changes_with_content() {
+        assert_ne!(sha256_hex(b"a"), sha256_hex(b"b"));
+    }
+
+    #[test]
+    fn for_module_none_without_esbuild_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let t = ShareTarget::for_module(tmp.path(), "media".into(), "m-1".into());
+        assert!(t.is_none(), "a backend-only module has no bundle to share");
+    }
+
+    #[test]
+    fn for_module_some_points_at_dist_bundle() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("web")).unwrap();
+        std::fs::write(tmp.path().join("web/esbuild.config.mjs"), "// build").unwrap();
+        let t = ShareTarget::for_module(tmp.path(), "media".into(), "m-1".into()).unwrap();
+        assert_eq!(t.slug, "media");
+        assert_eq!(t.module_id, "m-1");
+        assert_eq!(t.dist, tmp.path().join("web/dist/index.js"));
+    }
+
+    #[test]
+    fn share_once_skips_when_bundle_absent() {
+        // No dist file on disk → no network, no state change (nothing to
+        // gate against). A missing bundle is the pre-first-build state.
+        let tmp = tempfile::tempdir().unwrap();
+        let api_client = http::client(Duration::from_secs(5)).unwrap();
+        let upload_client = http::client(Duration::from_secs(5)).unwrap();
+        let mut creds = Credentials {
+            access_token: "AT".into(),
+            refresh_token: "RT".into(),
+            expires_at: std::time::SystemTime::now() + Duration::from_secs(3600),
+        };
+        let target = ShareTarget {
+            slug: "media".into(),
+            module_id: "m-1".into(),
+            dist: tmp.path().join("web/dist/index.js"),
+        };
+        let mut state = TargetState {
+            last_uploaded: None,
+            last_warned: None,
+        };
+        // apps_base points nowhere reachable; if it tried to upload this would
+        // error, but an absent bundle must return before any network call.
+        share_once(
+            &api_client,
+            &upload_client,
+            "http://127.0.0.1:1",
+            &mut creds,
+            &target,
+            &mut state,
+        );
+        assert!(state.last_uploaded.is_none());
+        assert!(state.last_warned.is_none());
+    }
+
+    #[test]
+    fn upload_bundle_presign_put_confirm_round_trip() {
+        // Full presign → PUT → confirm against mockito, proving the flow
+        // wires the presigned URL through and returns the confirmed CDN URL.
+        let mut server = mockito::Server::new();
+        let bytes = b"export default {}";
+        let hash = sha256_hex(bytes);
+
+        let presign = server
+            .mock("POST", "/v1/modules/m-1/dev-bundle/presign")
+            .match_header("authorization", "Bearer AT")
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "upload_url": format!("{}/s3-put", server.url()),
+                    "key": "modules/m-1/dev/u-1/hash/web/index.js",
+                    "expires_at": "2026-07-14T00:15:00Z"
+                })
+                .to_string(),
+            )
+            .create();
+        let put = server
+            .mock("PUT", "/s3-put")
+            .match_header("content-type", "application/javascript")
+            .with_status(200)
+            .create();
+        let confirm = server
+            .mock("POST", "/v1/modules/m-1/dev-bundle/confirm")
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"key":"modules/m-1/dev/u-1/hash/web/index.js"}"#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({ "url": "https://cdn.mirrorstack.ai/modules/m-1/dev/u-1/hash/web/index.js" })
+                    .to_string(),
+            )
+            .create();
+
+        let api_client = http::client(Duration::from_secs(5)).unwrap();
+        let upload_client = http::client(Duration::from_secs(5)).unwrap();
+        let mut creds = Credentials {
+            access_token: "AT".into(),
+            refresh_token: "RT".into(),
+            expires_at: std::time::SystemTime::now() + Duration::from_secs(3600),
+        };
+        let url = upload_bundle(
+            &api_client,
+            &upload_client,
+            &server.url(),
+            &mut creds,
+            "m-1",
+            bytes,
+            &hash,
+        )
+        .expect("upload ok");
+        assert_eq!(
+            url,
+            "https://cdn.mirrorstack.ai/modules/m-1/dev/u-1/hash/web/index.js"
+        );
+        presign.assert();
+        put.assert();
+        confirm.assert();
+    }
+
+    #[test]
+    fn share_once_skips_upload_when_hash_unchanged() {
+        // Pre-seed `last_uploaded` with the current bundle's hash: the scan
+        // must short-circuit before any network call (apps_base is
+        // unroutable, so an attempted upload would error and flip
+        // `last_warned`). This is the no-op-save gate.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("web/dist")).unwrap();
+        let bytes = b"export default {}";
+        std::fs::write(tmp.path().join("web/dist/index.js"), bytes).unwrap();
+
+        let api_client = http::client(Duration::from_secs(5)).unwrap();
+        let upload_client = http::client(Duration::from_secs(5)).unwrap();
+        let mut creds = Credentials {
+            access_token: "AT".into(),
+            refresh_token: "RT".into(),
+            expires_at: std::time::SystemTime::now() + Duration::from_secs(3600),
+        };
+        let target = ShareTarget {
+            slug: "media".into(),
+            module_id: "m-1".into(),
+            dist: tmp.path().join("web/dist/index.js"),
+        };
+        let mut state = TargetState {
+            last_uploaded: Some(sha256_hex(bytes)),
+            last_warned: None,
+        };
+        share_once(
+            &api_client,
+            &upload_client,
+            "http://127.0.0.1:1",
+            &mut creds,
+            &target,
+            &mut state,
+        );
+        // No upload attempted → no warning recorded, hash still marked live.
+        assert!(state.last_warned.is_none());
+        assert_eq!(
+            state.last_uploaded.as_deref(),
+            Some(sha256_hex(bytes).as_str())
+        );
+    }
+
+    #[test]
+    fn share_once_oversize_warns_once_and_skips() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("web/dist")).unwrap();
+        // One byte over the cap.
+        let big = vec![b'a'; (MAX_BUNDLE_BYTES + 1) as usize];
+        std::fs::write(tmp.path().join("web/dist/index.js"), &big).unwrap();
+
+        let api_client = http::client(Duration::from_secs(5)).unwrap();
+        let upload_client = http::client(Duration::from_secs(5)).unwrap();
+        let mut creds = Credentials {
+            access_token: "AT".into(),
+            refresh_token: "RT".into(),
+            expires_at: std::time::SystemTime::now() + Duration::from_secs(3600),
+        };
+        let target = ShareTarget {
+            slug: "media".into(),
+            module_id: "m-1".into(),
+            dist: tmp.path().join("web/dist/index.js"),
+        };
+        let mut state = TargetState {
+            last_uploaded: None,
+            last_warned: None,
+        };
+        share_once(
+            &api_client,
+            &upload_client,
+            "http://127.0.0.1:1",
+            &mut creds,
+            &target,
+            &mut state,
+        );
+        assert_eq!(state.last_warned.as_deref(), Some("__oversize__"));
+        assert!(state.last_uploaded.is_none());
+    }
+}


### PR DESCRIPTION
## What

Adds `mirrorstack dev --tunnel --share`: the opt-in "let others watch my live module" tier
of the dev-tunnel bundle design (`docs-temp/dev-tunnel-bundle-serving/DESIGN.md`). Default
`--tunnel` is unchanged (bundle serves from localhost, just you). Pairs with api-platform#364
(presign/confirm endpoint) and web-applications#153 (CDN livereload).

## Behavior

- `--share` + `--tunnel`: for each tunneled module, uploads the built `web/dist/index.js` to
  the CDN (presign → PUT → confirm) so **any** browser — remote too — can load it.
- `--share` **without** `--tunnel`: warns ("no effect without --tunnel") and does nothing —
  does not error.
- **Default (no `--share`): zero behavior change** — today's localhost/relay serving untouched.

## Where the upload runs (the load-bearing placement)

The **host** process (`run_outer`), because only it holds all three inputs at once:
- **user token** — `credentials.json` is host-side and never mounted into the compose runner;
- **built bytes** — esbuild writes `web/dist/index.js` in the container, visible on the host
  via the `.:/modules` bind mount;
- **tunnel session** — registration is host-side (`open_tunnels`), and confirm updates that
  session's pointer.

The inner container has bytes but neither token nor tunnel, so it's the wrong place.

## Trigger + hash-gate

No cross-process rebuild signal is available host-side (esbuild's `onEnd`/SSE lives in the
container), so the host watcher **polls each bundle's content every 2s** (matching the Go
supervisor's rebuild poll). Per module it tracks `last_uploaded: sha256` — unchanged bytes are
a no-op (no PUT storm), first-appearance and changed-hash both upload. First scan runs
immediately so startup isn't delayed.

## Flow + resilience

`read → sha256 → presign{content_type,size_bytes,sha256} → PUT (Content-Type only, presigned
URL carries auth) → confirm{key}`. `moduleId` from the same resolver tunnel registration uses.
Both platform calls go through the existing `with_refresh_retry` (access-token refresh). 32 MiB
client cap mirrors the publisher. **Best-effort throughout** — any failure logs one scoped
warning and continues; `last_uploaded` is left unchanged so the next tick retries, and repeat
warnings are deduped. Never crashes the tunnel or blocks serving (consistent with #58).

## Tests / verify

`cargo fmt --check`, `cargo build`, `cargo clippy --all-targets -- -D warnings` all clean;
`cargo test` → 229 passed (15 new: presign/confirm success + 413/404/401/422/403 error cases,
sha256 hashing, hash-gate skip-on-unchanged, oversize-warn-once, full presign→PUT→confirm
round-trip via mockito).

## Deploy

CLI rebuild only (no platform deploy). Needs api-platform#364 deployed to actually serve the
uploaded bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)