### PR TITLE
ci: restrict workflow token to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ env:
   CARGO_INCREMENTAL: "0"
   RUSTFLAGS: "-D warnings"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint (fmt + clippy)


### PR DESCRIPTION
## Summary

- declare explicit workflow-level permissions
- limit the CI GITHUB_TOKEN to read-only repository contents
- resolve the CodeQL missing-workflow-permissions findings

## Validation

- actionlint 1.7.12
- git diff --check