### PR TITLE
fix: relay module 3xx verbatim — never follow redirects in the tunnel client

### DIFF
--- a/src/commands/dev/tunnel.rs
+++ b/src/commands/dev/tunnel.rs
@@ -340,12 +340,10 @@ pub(super) async fn open(
     .context("dev: register_ack timeout")??;
 
     let shutdown = Arc::new(Notify::new());
-    // Async client for the heartbeat's local manifest fetch. Client-level
-    // timeout guards every GET so a wedged module can't stall the ping loop.
-    let http = reqwest::Client::builder()
-        .timeout(MANIFEST_FETCH_TIMEOUT)
-        .build()
-        .context("dev: build manifest-hash http client")?;
+    // Async client for the heartbeat's local manifest fetch and every WSS
+    // HTTP-relay call. Client-level timeout guards every GET so a wedged
+    // module can't stall the ping loop.
+    let http = relay_http_client().context("dev: build manifest-hash http client")?;
     // Built once per connection and shared via `Arc`: `local_url`,
     // `service_token`, and `internal_secret` are invariant for the whole
     // tunnel's lifetime, so every spawned relay task should bump a refcount
@@ -675,6 +673,21 @@ async fn relay_rpc_req(
             msg: Message::Text(body),
         });
     }
+}
+
+/// HTTP client for the tunnel's local calls (heartbeat manifest GET +
+/// relayed `rpc.req`). Redirects are NEVER followed: a module's 3xx (e.g.
+/// oauth-core's `/public/start` → accounts.google.com) must be relayed
+/// verbatim so the BROWSER chases the Location — following it here relays
+/// the redirect target's response instead, which breaks the flow outright
+/// and (with Google's multi-KB headers) blows API Gateway's response
+/// limits into a bare 502. Dispatch's direct-dial client pins the same
+/// semantics with Go's `http.ErrUseLastResponse`.
+fn relay_http_client() -> reqwest::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(MANIFEST_FETCH_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
 }
 
 /// Attach the CLI-minted `X-MS-Platform-Token`/`X-MS-Internal-Secret`
@@ -1117,6 +1130,58 @@ mod tests {
         assert_eq!(payload["status"], 201);
         let body_b64 = payload["body"].as_str().unwrap();
         assert_eq!(STANDARD.decode(body_b64).unwrap(), b"hi there");
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn relay_rpc_req_relays_redirect_verbatim() {
+        // A module 3xx (oauth-core /public/start → accounts.google.com) must
+        // reach dispatch as-is so the BROWSER follows the Location. reqwest's
+        // default policy chases it and relays the redirect target's response
+        // instead — the bug this pins. Uses the production client
+        // (relay_http_client, Policy::none()), not Client::new().
+        let mut server = mockito::Server::new_async().await;
+        let m = server
+            .mock("GET", "/public/start")
+            .with_status(302)
+            .with_header(
+                "location",
+                "https://accounts.google.com/o/oauth2/v2/auth?state=x",
+            )
+            .with_header("set-cookie", "ms_oauth_state=abc; Path=/; HttpOnly")
+            .create_async()
+            .await;
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<RelayReply>();
+        let req = RpcReqPayload {
+            method: "GET".to_string(),
+            path: "/public/start".to_string(),
+            query: String::new(),
+            headers: HashMap::new(),
+            body: None,
+        };
+        relay_rpc_req(
+            tx,
+            relay_http_client().unwrap(),
+            test_ctx(server.url(), "ptok", Some("sec")),
+            "frm_redirect".to_string(),
+            req,
+        )
+        .await;
+
+        let frame = recv_frame(&mut rx).await;
+        assert_eq!(frame.frame_type, FrameType::RpcResp);
+        assert_eq!(frame.corr_id.as_deref(), Some("frm_redirect"));
+        let payload = frame.payload.unwrap();
+        assert_eq!(payload["status"], 302);
+        assert_eq!(
+            payload["headers"]["location"][0],
+            "https://accounts.google.com/o/oauth2/v2/auth?state=x"
+        );
+        assert_eq!(
+            payload["headers"]["set-cookie"][0],
+            "ms_oauth_state=abc; Path=/; HttpOnly"
+        );
         m.assert_async().await;
     }
 

--- a/src/scheme/mod.rs
+++ b/src/scheme/mod.rs
@@ -4,6 +4,13 @@
 //! to the waiting `login` command. Unsupported platforms (Windows, headless)
 //! fall back to OOB paste.
 
+// The relay, per-OS registration, and their error/helper types are all built
+// only on unix (see the cfg(unix) module + item gates below). On other targets
+// (the windows CI build) every one of them is legitimately unused, so silence
+// dead_code there rather than cfg-gating each type, trait, and helper piecemeal
+// — the whole module is inert on Windows by design.
+#![cfg_attr(not(unix), allow(dead_code))]
+
 use std::time::Duration;
 
 use url::Url;

--- a/src/scheme/tests.rs
+++ b/src/scheme/tests.rs
@@ -79,7 +79,8 @@ mod unix {
     #[test]
     fn relay_times_out() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let relay = UnixRelay::bind_path(dir.path().join("to.sock"), "TOSTATE").expect("bind relay");
+        let relay =
+            UnixRelay::bind_path(dir.path().join("to.sock"), "TOSTATE").expect("bind relay");
         let result = relay.wait(Duration::from_millis(250));
         assert!(matches!(result, Err(WaitError::Timeout)));
     }


### PR DESCRIPTION
## Summary

The tunnel's shared `reqwest` client had no redirect policy, so the WSS HTTP-relay followed a module's 302 (oauth-core `/public/start` → accounts.google.com) and relayed *Google's* response; its multi-KB headers exceed API Gateway's response limits and the browser gets a bare Cloudflare 502 — every dev-tunnel OAuth flow was broken. Dispatch's direct-dial leg already pins verbatim-relay semantics (`CheckRedirect: http.ErrUseLastResponse`, "RELAY redirects, don't follow them"); this gives the Rust leg the equivalent: `redirect::Policy::none()` via a `relay_http_client()` helper shared with the tests.

Root-cause evidence + live browser/curl repro: mirrorstack-ai/mirrorstack-core-v2#219

Closes #65

## Verification

- New regression test `relay_rpc_req_relays_redirect_verbatim` (302 + Location + Set-Cookie relayed as-is, built on the production client) — all 30 tunnel tests pass
- Heartbeat manifest GET shares the client and never redirects — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)