### PR TITLE
feat(deploy): --oidc deploy-grant exchange and MIRRORSTACK_TOKEN fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ mirrorstack --help             # Show help
 mirrorstack --version          # Show CLI version
 ```
 
+## Deploy tokens
+
+Create a token in the app's deployment settings on the platform. Its value is
+shown exactly once and does not expire.
+
+```bash
+export MIRRORSTACK_TOKEN=...
+mirrorstack apps web deploy --app <slug> --dir out
+```
+
+Revoke the token when it is no longer needed.
+
 ## Local development
 
 Build:

--- a/src/api.rs
+++ b/src/api.rs
@@ -716,14 +716,55 @@ impl std::fmt::Debug for DeployGrantError {
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct DeployGrantErrorBody {
-    code: String,
-    message: String,
+#[derive(Default, Deserialize)]
+struct DeployGrantErrorFields {
+    #[serde(default)]
+    code: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
     #[serde(default)]
     sub: Option<String>,
     #[serde(default)]
     approval_url: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct DeployGrantErrorBody {
+    #[serde(default)]
+    code: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    sub: Option<String>,
+    #[serde(default)]
+    approval_url: Option<String>,
+    #[serde(default)]
+    error: Option<DeployGrantErrorFields>,
+}
+
+impl std::fmt::Debug for DeployGrantErrorBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("DeployGrantErrorBody(<redacted>)")
+    }
+}
+
+impl DeployGrantErrorBody {
+    fn merged(self) -> Option<(String, String, Option<String>, Option<String>)> {
+        let inner = self.error.unwrap_or_default();
+        let flat_code = self.code.filter(|code| !code.trim().is_empty());
+        let inner_code = inner.code.filter(|code| !code.trim().is_empty());
+        let (code, message) = match flat_code {
+            Some(code) => (code, self.message.or(inner.message)),
+            None => (inner_code?, inner.message.or(self.message)),
+        };
+
+        Some((
+            code,
+            message.unwrap_or_default(),
+            inner.sub.or(self.sub),
+            inner.approval_url.or(self.approval_url),
+        ))
+    }
 }
 
 /// Exchange a GitHub Actions OIDC JWT for an app+environment-bound deploy
@@ -751,26 +792,27 @@ pub fn exchange_deploy_grant(
     let Ok(error) = serde_json::from_slice::<DeployGrantErrorBody>(&body) else {
         return Err(DeployGrantError::Unexpected { status: status_u16 });
     };
-    match error.code.as_str() {
-        "binding_pending" => match (error.sub, error.approval_url) {
+    let Some((code, message, sub, approval_url)) = error.merged() else {
+        return Err(DeployGrantError::Unexpected { status: status_u16 });
+    };
+    match code.as_str() {
+        "binding_pending" => match (sub, approval_url) {
             (Some(sub), Some(approval_url)) => Err(DeployGrantError::BindingPending {
                 sub,
                 approval_url,
-                message: error.message,
+                message,
             }),
             _ => Err(DeployGrantError::Server {
                 status: status_u16,
-                code: error.code,
-                message: error.message,
+                code,
+                message,
             }),
         },
-        "binding_revoked" => Err(DeployGrantError::BindingRevoked {
-            message: error.message,
-        }),
+        "binding_revoked" => Err(DeployGrantError::BindingRevoked { message }),
         _ => Err(DeployGrantError::Server {
             status: status_u16,
-            code: error.code,
-            message: error.message,
+            code,
+            message,
         }),
     }
 }
@@ -1153,6 +1195,27 @@ mod tests {
         http::client(Duration::from_secs(15)).expect("client")
     }
 
+    fn deploy_grant_exchange_error(status: usize, body: serde_json::Value) -> DeployGrantError {
+        let mut server = Server::new();
+        let response = server
+            .mock("POST", "/v1/oidc/deploy-grant")
+            .with_status(status)
+            .with_body(body.to_string())
+            .create();
+        let error = exchange_deploy_grant(
+            &test_client(),
+            &server.url(),
+            &DeployGrantInput {
+                token: "github-jwt",
+                app: "company",
+                env: "prod",
+            },
+        )
+        .expect_err("exchange error");
+        response.assert();
+        error
+    }
+
     #[test]
     fn me_success() {
         let mut server = Server::new();
@@ -1273,17 +1336,125 @@ mod tests {
         .expect_err("pending");
         match error {
             DeployGrantError::BindingPending {
-                sub, approval_url, ..
+                sub,
+                approval_url,
+                message,
             } => {
                 assert_eq!(sub, "repo:org/repo:ref:refs/heads/main");
                 assert_eq!(
                     approval_url,
                     "https://apps.mirrorstack.ai/apps/app-1/settings/deployment"
                 );
+                assert_eq!(message, "approval required");
             }
             other => panic!("expected binding payload, got {other:?}"),
         }
         pending.assert();
+    }
+
+    #[test]
+    fn deploy_grant_nested_and_mixed_binding_errors_preserve_payload() {
+        let sub = "repo:org/repo:ref:refs/heads/main";
+        let approval_url = "https://apps.example/approve";
+        for (body, expected_message) in [
+            (
+                json!({
+                    "error": {
+                        "code": "binding_pending",
+                        "message": "nested approval required",
+                        "sub": sub,
+                        "approval_url": approval_url
+                    }
+                }),
+                "nested approval required",
+            ),
+            (
+                json!({
+                    "sub": sub,
+                    "approval_url": approval_url,
+                    "error": {
+                        "code": "binding_pending",
+                        "message": "nested approval required"
+                    }
+                }),
+                "nested approval required",
+            ),
+            (
+                json!({
+                    "code": "binding_pending",
+                    "message": "flat approval required",
+                    "sub": "outer-sub",
+                    "approval_url": "https://outer.example/approve",
+                    "error": {
+                        "sub": sub,
+                        "approval_url": approval_url
+                    }
+                }),
+                "flat approval required",
+            ),
+        ] {
+            match deploy_grant_exchange_error(403, body) {
+                DeployGrantError::BindingPending {
+                    sub: actual_sub,
+                    approval_url: actual_approval_url,
+                    message,
+                } => {
+                    assert_eq!(actual_sub, sub);
+                    assert_eq!(actual_approval_url, approval_url);
+                    assert_eq!(message, expected_message);
+                }
+                other => panic!("expected binding payload, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn deploy_grant_flat_and_nested_server_errors_preserve_code_and_message() {
+        for (status, code, message) in [
+            (401, "invalid_token", "token rejected"),
+            (404, "app_not_found", "app missing"),
+            (429, "rate_limited", "try later"),
+        ] {
+            let fields = json!({"code": code, "message": message});
+            for body in [fields.clone(), json!({"error": fields})] {
+                match deploy_grant_exchange_error(status, body) {
+                    DeployGrantError::Server {
+                        status: actual_status,
+                        code: actual_code,
+                        message: actual_message,
+                    } => {
+                        assert_eq!(actual_status, status as u16);
+                        assert_eq!(actual_code, code);
+                        assert_eq!(actual_message, message);
+                    }
+                    other => panic!("expected actionable server error, got {other:?}"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn deploy_grant_flat_and_nested_revoked_errors_preserve_message() {
+        let fields = json!({
+            "code": "binding_revoked",
+            "message": "binding was revoked"
+        });
+        for body in [fields.clone(), json!({"error": fields})] {
+            match deploy_grant_exchange_error(403, body) {
+                DeployGrantError::BindingRevoked { message } => {
+                    assert_eq!(message, "binding was revoked");
+                }
+                other => panic!("expected binding revoked, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn deploy_grant_error_without_code_is_unexpected() {
+        assert!(matches!(
+            deploy_grant_exchange_error(502, json!({"detail": "nope"})),
+            DeployGrantError::Unexpected { status: 502 }
+        ));
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -631,6 +631,150 @@ pub struct CreatedDeploy {
     pub uploads: Vec<UploadTarget>,
 }
 
+#[derive(Serialize)]
+pub struct DeployGrantInput<'a> {
+    pub token: &'a str,
+    pub app: &'a str,
+    pub env: &'a str,
+}
+
+impl std::fmt::Debug for DeployGrantInput<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeployGrantInput")
+            .field("token", &"<redacted>")
+            .field("app", &self.app)
+            .field("env", &self.env)
+            .finish()
+    }
+}
+
+#[derive(Deserialize)]
+pub struct DeployGrant {
+    pub grant: String,
+    #[allow(dead_code)] // expiry is server-enforced; the CLI diagnoses a rejected grant on 401
+    pub expires_at: String,
+    pub app_id: String,
+    pub env: String,
+}
+
+impl std::fmt::Debug for DeployGrant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("DeployGrant(<redacted>)")
+    }
+}
+
+/// Errors from the public OIDC exchange retain the binding payload that
+/// makes an otherwise opaque 403 actionable to a CI operator.
+#[derive(Error)]
+pub enum DeployGrantError {
+    #[error("OIDC deploy-grant request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("OIDC deploy-grant response could not be read: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("OIDC deploy-grant response was invalid: {0}")]
+    Decode(#[from] serde_json::Error),
+    #[error("{message}")]
+    BindingPending {
+        sub: String,
+        approval_url: String,
+        message: String,
+    },
+    #[error("{message}")]
+    BindingRevoked { message: String },
+    #[error("OIDC deploy-grant exchange failed: {code}: {message}")]
+    Server {
+        status: u16,
+        code: String,
+        message: String,
+    },
+    #[error("OIDC deploy-grant exchange returned HTTP {status}")]
+    Unexpected { status: u16 },
+}
+
+impl std::fmt::Debug for DeployGrantError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(_) => f.write_str("DeployGrantError::Http(<redacted>)"),
+            Self::Io(_) => f.write_str("DeployGrantError::Io(<redacted>)"),
+            Self::Decode(_) => f.write_str("DeployGrantError::Decode(<redacted>)"),
+            Self::BindingPending { .. } => {
+                f.write_str("DeployGrantError::BindingPending(<redacted>)")
+            }
+            Self::BindingRevoked { .. } => {
+                f.write_str("DeployGrantError::BindingRevoked(<redacted>)")
+            }
+            Self::Server { status, .. } => f
+                .debug_struct("DeployGrantError::Server")
+                .field("status", status)
+                .field("details", &"<redacted>")
+                .finish(),
+            Self::Unexpected { status } => f
+                .debug_struct("DeployGrantError::Unexpected")
+                .field("status", status)
+                .finish(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DeployGrantErrorBody {
+    code: String,
+    message: String,
+    #[serde(default)]
+    sub: Option<String>,
+    #[serde(default)]
+    approval_url: Option<String>,
+}
+
+/// Exchange a GitHub Actions OIDC JWT for an app+environment-bound deploy
+/// grant. This endpoint is intentionally public; adding bearer auth here
+/// would violate the deploy-grant contract.
+pub fn exchange_deploy_grant(
+    http: &Client,
+    apps_base: &str,
+    input: &DeployGrantInput<'_>,
+) -> Result<DeployGrant, DeployGrantError> {
+    let endpoint = format!("{}/v1/oidc/deploy-grant", apps_base.trim_end_matches('/'));
+    let resp = http
+        .post(&endpoint)
+        .header("Accept", "application/json")
+        .json(input)
+        .send()?;
+    let status = resp.status();
+    let status_u16 = status.as_u16();
+    let body = http::read_capped(resp)?;
+
+    if status.is_success() {
+        return Ok(serde_json::from_slice(&body)?);
+    }
+
+    let Ok(error) = serde_json::from_slice::<DeployGrantErrorBody>(&body) else {
+        return Err(DeployGrantError::Unexpected { status: status_u16 });
+    };
+    match error.code.as_str() {
+        "binding_pending" => match (error.sub, error.approval_url) {
+            (Some(sub), Some(approval_url)) => Err(DeployGrantError::BindingPending {
+                sub,
+                approval_url,
+                message: error.message,
+            }),
+            _ => Err(DeployGrantError::Server {
+                status: status_u16,
+                code: error.code,
+                message: error.message,
+            }),
+        },
+        "binding_revoked" => Err(DeployGrantError::BindingRevoked {
+            message: error.message,
+        }),
+        _ => Err(DeployGrantError::Server {
+            status: status_u16,
+            code: error.code,
+            message: error.message,
+        }),
+    }
+}
+
 /// POST /v1/apps/{appId}/deploys — register a pending deploy and mint one
 /// presigned S3 PUT per manifest file (15-minute expiry). Owner/admin
 /// gated; the platform re-validates the manifest (≤500 files, ≤25MB
@@ -1063,6 +1207,83 @@ mod tests {
             }
             other => panic!("expected Unexpected, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn deploy_grant_exchange_is_public_and_preserves_binding_payload() {
+        let mut server = Server::new();
+        let success = server
+            .mock("POST", "/v1/oidc/deploy-grant")
+            .match_header("authorization", mockito::Matcher::Missing)
+            .match_body(mockito::Matcher::Json(json!({
+                "token": "github-jwt",
+                "app": "company",
+                "env": "prod"
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "grant": "grant-secret",
+                    "expires_at": "2026-07-27T05:30:00Z",
+                    "app_id": "app-1",
+                    "env": "prod"
+                })
+                .to_string(),
+            )
+            .create();
+
+        let grant = exchange_deploy_grant(
+            &test_client(),
+            &server.url(),
+            &DeployGrantInput {
+                token: "github-jwt",
+                app: "company",
+                env: "prod",
+            },
+        )
+        .expect("exchange");
+        assert_eq!(grant.grant, "grant-secret");
+        assert_eq!(grant.app_id, "app-1");
+        assert_eq!(grant.env, "prod");
+        success.assert();
+
+        let pending = server
+            .mock("POST", "/v1/oidc/deploy-grant")
+            .match_header("authorization", mockito::Matcher::Missing)
+            .with_status(403)
+            .with_body(
+                json!({
+                    "code": "binding_pending",
+                    "message": "approval required",
+                    "sub": "repo:org/repo:ref:refs/heads/main",
+                    "approval_url": "https://apps.mirrorstack.ai/apps/app-1/settings/deployment"
+                })
+                .to_string(),
+            )
+            .create();
+        let error = exchange_deploy_grant(
+            &test_client(),
+            &server.url(),
+            &DeployGrantInput {
+                token: "different-jwt",
+                app: "company",
+                env: "prod",
+            },
+        )
+        .expect_err("pending");
+        match error {
+            DeployGrantError::BindingPending {
+                sub, approval_url, ..
+            } => {
+                assert_eq!(sub, "repo:org/repo:ref:refs/heads/main");
+                assert_eq!(
+                    approval_url,
+                    "https://apps.mirrorstack.ai/apps/app-1/settings/deployment"
+                );
+            }
+            other => panic!("expected binding payload, got {other:?}"),
+        }
+        pending.assert();
     }
 
     #[test]

--- a/src/commands/app/deploy.rs
+++ b/src/commands/app/deploy.rs
@@ -114,6 +114,7 @@ pub fn run(args: DeployArgs) -> Result<()> {
     };
 
     let apps_base = resolve_base(ENV_APPS_API_URL, DEFAULT_APPS_API_BASE);
+    let oidc_audience = deploy_auth::resolve_oidc_audience(|name| std::env::var(name).ok());
     let client = http::client(Duration::from_secs(15))?;
 
     let selected = deploy_auth::select_deploy_auth(
@@ -131,6 +132,7 @@ pub fn run(args: DeployArgs) -> Result<()> {
                 &apps_base,
                 &request_url,
                 &request_token,
+                &oidc_audience,
                 &args.app,
                 &args.env,
             )?;

--- a/src/commands/app/deploy.rs
+++ b/src/commands/app/deploy.rs
@@ -30,13 +30,12 @@ use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::blocking::Client;
 use sha2::{Digest, Sha256};
 
-use crate::api::{self, ApiError, CreateAppDeployInput, DeployFile};
-use crate::commands::{
-    DEFAULT_APPS_API_BASE, ENV_APPS_API_URL, ok_mark, resolve_base, session_expired,
-};
-use crate::credentials;
+use crate::api::{self, CreateAppDeployInput, DeployFile};
+use crate::commands::{DEFAULT_APPS_API_BASE, ENV_APPS_API_URL, ok_mark, resolve_base};
+use crate::credentials::load_or_login_hint;
 use crate::http;
 
+use super::deploy_auth::{self, DeployAuth, SelectedDeployAuth};
 use super::ssr;
 use super::with_spinner;
 
@@ -94,6 +93,9 @@ pub struct DeployArgs {
     /// this to override the detection.
     #[arg(long, value_enum)]
     runtime: Option<RuntimeArg>,
+    /// Authenticate with the GitHub Actions OIDC identity for this job.
+    #[arg(long)]
+    oidc: bool,
 }
 
 pub fn run(args: DeployArgs) -> Result<()> {
@@ -111,32 +113,97 @@ pub fn run(args: DeployArgs) -> Result<()> {
         None => ssr::looks_like_standalone(&dir),
     };
 
-    let mut creds = credentials::load_or_login_hint()?;
     let apps_base = resolve_base(ENV_APPS_API_URL, DEFAULT_APPS_API_BASE);
     let client = http::client(Duration::from_secs(15))?;
 
-    // Resolve --app (ID or slug) to the app row: the deploy endpoints take
-    // the ID, and the final URL needs the slug. Member-scoped, so this
-    // doubles as an access check before any upload work.
-    let app = match credentials::with_refresh_retry(&mut creds, |tok| {
-        api::get_app(&client, &apps_base, tok, &args.app)
-    }) {
-        Ok(Some(a)) => a,
-        Ok(None) => {
-            return Err(anyhow!(
-                "app '{}' not found (pass an app ID or slug you're a member of)",
-                args.app
-            ));
+    let selected = deploy_auth::select_deploy_auth(
+        args.oidc,
+        |name| std::env::var(name).ok(),
+        load_or_login_hint,
+    )?;
+    let (target, mut auth) = match selected {
+        SelectedDeployAuth::Oidc {
+            request_url,
+            request_token,
+        } => {
+            let exchanged = deploy_auth::exchange_oidc(
+                &client,
+                &apps_base,
+                &request_url,
+                &request_token,
+                &args.app,
+                &args.env,
+            )?;
+            oidc_target(exchanged, &args.env)?
         }
-        Err(ApiError::Unauthenticated) => return Err(session_expired()),
-        Err(e) => return Err(e.into()),
+        SelectedDeployAuth::Ready(DeployAuth::Token(token)) => (
+            DeployTarget {
+                id: args.app.clone(),
+                slug: None,
+            },
+            DeployAuth::Token(token),
+        ),
+        SelectedDeployAuth::Ready(mut user @ DeployAuth::User(_)) => {
+            // Only a user principal may resolve a slug/UUID through the
+            // management endpoint. Deploy principals are endpoint-limited.
+            let app = match user.with_retry(|tok| api::get_app(&client, &apps_base, tok, &args.app))
+            {
+                Ok(Some(app)) => app,
+                Ok(None) => {
+                    return Err(anyhow!(
+                        "app '{}' not found (pass an app ID or slug you're a member of)",
+                        args.app
+                    ));
+                }
+                Err(error) => return Err(user.deploy_error(error)),
+            };
+            (
+                DeployTarget {
+                    id: app.id,
+                    slug: Some(app.slug),
+                },
+                user,
+            )
+        }
+        SelectedDeployAuth::Ready(DeployAuth::Grant(_)) => {
+            unreachable!("grants are created only by the OIDC exchange")
+        }
     };
 
     if is_ssr {
-        deploy_ssr(&args, &dir, &app, &mut creds, &apps_base, &client)
+        deploy_ssr(&args, &dir, &target, &mut auth, &apps_base, &client)
     } else {
-        deploy_static(&args, &dir, &app, &mut creds, &apps_base, &client)
+        deploy_static(&args, &dir, &target, &mut auth, &apps_base, &client)
     }
+}
+
+#[derive(Debug)]
+struct DeployTarget {
+    id: String,
+    slug: Option<String>,
+}
+
+impl DeployTarget {
+    fn label<'a>(&'a self, app_ref: &'a str) -> &'a str {
+        self.slug.as_deref().unwrap_or(app_ref)
+    }
+}
+
+fn oidc_target(grant: api::DeployGrant, requested_env: &str) -> Result<(DeployTarget, DeployAuth)> {
+    if grant.env != requested_env {
+        return Err(anyhow!(
+            "OIDC deploy grant was bound to environment '{}' but --env requested '{}'; refusing to deploy",
+            grant.env,
+            requested_env
+        ));
+    }
+    Ok((
+        DeployTarget {
+            id: grant.app_id,
+            slug: None,
+        },
+        DeployAuth::Grant(grant.grant),
+    ))
 }
 
 /// Today's flow, byte-for-byte unchanged: walk `dir` into a static-file
@@ -144,8 +211,8 @@ pub fn run(args: DeployArgs) -> Result<()> {
 fn deploy_static(
     args: &DeployArgs,
     dir: &Path,
-    app: &api::App,
-    creds: &mut credentials::Credentials,
+    app: &DeployTarget,
+    creds: &mut DeployAuth,
     apps_base: &str,
     client: &Client,
 ) -> Result<()> {
@@ -156,7 +223,9 @@ fn deploy_static(
         "  {} {} → {} ({} files, {})",
         style("Deploying:").dim(),
         style(dir.display()).bold(),
-        style(format!("{}@{}", app.slug, args.env)).cyan().bold(),
+        style(format!("{}@{}", app.label(&args.app), args.env))
+            .cyan()
+            .bold(),
         files.len(),
         human_bytes(bytes_total)
     );
@@ -170,7 +239,7 @@ fn deploy_static(
         })
         .collect();
     let created = with_spinner("Creating deploy…", || {
-        credentials::with_refresh_retry(creds, |tok| {
+        creds.with_retry(|tok| {
             api::create_app_deploy(
                 client,
                 apps_base,
@@ -185,7 +254,7 @@ fn deploy_static(
             )
         })
     })
-    .map_err(api_err)?;
+    .map_err(|error| creds.deploy_error(error))?;
 
     // Presigned URLs carry their own auth — a dedicated client without the
     // bearer token and with an upload-sized timeout.
@@ -206,8 +275,8 @@ fn deploy_static(
 fn deploy_ssr(
     args: &DeployArgs,
     dir: &Path,
-    app: &api::App,
-    creds: &mut credentials::Credentials,
+    app: &DeployTarget,
+    creds: &mut DeployAuth,
     apps_base: &str,
     client: &Client,
 ) -> Result<()> {
@@ -225,8 +294,8 @@ fn deploy_ssr(
 fn deploy_ssr_with_cap(
     args: &DeployArgs,
     dir: &Path,
-    app: &api::App,
-    creds: &mut credentials::Credentials,
+    app: &DeployTarget,
+    creds: &mut DeployAuth,
     apps_base: &str,
     client: &Client,
     max_bundle_bytes: u64,
@@ -239,7 +308,9 @@ fn deploy_ssr_with_cap(
         "  {} {} → {} (ssr bundle, {})",
         style("Deploying:").dim(),
         style(dir.display()).bold(),
-        style(format!("{}@{}", app.slug, args.env)).cyan().bold(),
+        style(format!("{}@{}", app.label(&args.app), args.env))
+            .cyan()
+            .bold(),
         human_bytes(size)
     );
 
@@ -263,7 +334,7 @@ fn deploy_ssr_with_cap(
     // Lambda bundle, not a static-file manifest entry — see the PR
     // description for the request-shape assumption this rests on.
     let created = with_spinner("Creating deploy…", || {
-        credentials::with_refresh_retry(creds, |tok| {
+        creds.with_retry(|tok| {
             api::create_app_deploy(
                 client,
                 apps_base,
@@ -278,7 +349,7 @@ fn deploy_ssr_with_cap(
             )
         })
     })
-    .map_err(api_err)?;
+    .map_err(|error| creds.deploy_error(error))?;
 
     let bundle_file = ManifestFile {
         rel_path: "ssr-bundle.zip".to_string(),
@@ -303,24 +374,24 @@ fn deploy_ssr_with_cap(
 /// lines either way.
 fn finish_deploy(
     args: &DeployArgs,
-    app: &api::App,
-    creds: &mut credentials::Credentials,
+    app: &DeployTarget,
+    creds: &mut DeployAuth,
     apps_base: &str,
     client: &Client,
     deploy_id: &str,
 ) -> Result<()> {
     with_spinner("Finalizing…", || {
-        credentials::with_refresh_retry(creds, |tok| {
-            api::finalize_app_deploy(client, apps_base, tok, &app.id, deploy_id)
-        })
+        creds.with_retry(|tok| api::finalize_app_deploy(client, apps_base, tok, &app.id, deploy_id))
     })
-    .map_err(api_err)?;
+    .map_err(|error| creds.deploy_error(error))?;
 
     if args.no_activate {
         eprintln!(
             "{} deployed {} (not activated)",
             ok_mark(),
-            style(format!("{}@{}", app.slug, args.env)).cyan().bold()
+            style(format!("{}@{}", app.label(&args.app), args.env))
+                .cyan()
+                .bold()
         );
         eprintln!("  {} {}", style("deploy:").dim(), deploy_id);
         eprintln!(
@@ -331,36 +402,30 @@ fn finish_deploy(
     }
 
     with_spinner("Activating…", || {
-        credentials::with_refresh_retry(creds, |tok| {
+        creds.with_retry(|tok| {
             api::activate_app_stage(client, apps_base, tok, &app.id, &args.env, deploy_id)
         })
     })
-    .map_err(api_err)?;
+    .map_err(|error| creds.deploy_error(error))?;
 
     eprintln!(
         "{} deployed {}",
         ok_mark(),
-        style(format!("{}@{}", app.slug, args.env)).cyan().bold()
-    );
-    eprintln!("  {} {}", style("deploy:").dim(), deploy_id);
-    eprintln!(
-        "  {} {}",
-        style("url:").dim(),
-        style(format!("https://{}.mirrorstack.app", app.slug))
+        style(format!("{}@{}", app.label(&args.app), args.env))
             .cyan()
             .bold()
     );
-    Ok(())
-}
-
-/// Map the API error vocabulary onto command-level errors, the same shape
-/// the other commands print (`code: message`, login hint on 401).
-fn api_err(e: ApiError) -> anyhow::Error {
-    match e {
-        ApiError::Unauthenticated => session_expired(),
-        ApiError::Server { code, message, .. } => anyhow!("{code}: {message}"),
-        other => other.into(),
+    eprintln!("  {} {}", style("deploy:").dim(), deploy_id);
+    if let Some(slug) = &app.slug {
+        eprintln!(
+            "  {} {}",
+            style("url:").dim(),
+            style(format!("https://{slug}.mirrorstack.app"))
+                .cyan()
+                .bold()
+        );
     }
+    Ok(())
 }
 
 /// One file under the deploy root: its manifest entry plus where to read
@@ -760,6 +825,8 @@ mod tests {
     use mockito::Server;
     use serde_json::json;
 
+    use crate::credentials;
+
     fn ssr_fixture(dir: &Path) {
         write(dir, ".next/standalone/server.js", "server");
         write(dir, ".next/standalone/node_modules/pkg/index.js", "pkg");
@@ -774,25 +841,23 @@ mod tests {
             note: None,
             no_activate: false,
             runtime: None,
+            oidc: false,
         }
     }
 
-    fn test_app() -> api::App {
-        api::App {
+    fn test_app() -> DeployTarget {
+        DeployTarget {
             id: "a-1".to_string(),
-            name: "Test App".to_string(),
-            slug: "test-app".to_string(),
-            owner_id: None,
-            created_at: None,
+            slug: Some("test-app".to_string()),
         }
     }
 
-    fn test_creds() -> credentials::Credentials {
-        credentials::Credentials {
+    fn test_creds() -> DeployAuth {
+        DeployAuth::User(credentials::Credentials {
             access_token: "AT".to_string(),
             refresh_token: "RT".to_string(),
             expires_at: std::time::SystemTime::now() + Duration::from_secs(3600),
-        }
+        })
     }
 
     /// Accepts exactly one connection, reads a full HTTP request (headers +
@@ -981,5 +1046,85 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("too large"), "{msg}");
         assert!(msg.contains("1 B"), "{msg}");
+    }
+
+    #[test]
+    fn deploy_token_path_needs_no_stored_credentials_or_app_lookup() {
+        let dir = TempDir::new().unwrap();
+        write(dir.path(), "index.html", "hello");
+
+        let loader_called = std::cell::Cell::new(false);
+        let selected = deploy_auth::select_deploy_auth(
+            false,
+            |name| (name == deploy_auth::ENV_DEPLOY_TOKEN).then(|| "token-secret".to_string()),
+            || {
+                loader_called.set(true);
+                Err(anyhow!("no credentials file"))
+            },
+        )
+        .expect("deploy token selected");
+        assert!(!loader_called.get(), "stored credentials were loaded");
+        let SelectedDeployAuth::Ready(mut auth @ DeployAuth::Token(_)) = selected else {
+            panic!("expected deploy token");
+        };
+
+        let mut server = Server::new();
+        let no_lookup = server.mock("GET", "/v1/apps/company").expect(0).create();
+        let create = server
+            .mock("POST", "/v1/apps/company/deploys")
+            .match_header("authorization", "Bearer token-secret")
+            .with_status(201)
+            .with_body(json!({"deploy_id": "d-1", "uploads": []}).to_string())
+            .create();
+        let finalize = server
+            .mock("POST", "/v1/apps/company/deploys/d-1/finalize")
+            .match_header("authorization", "Bearer token-secret")
+            .with_status(200)
+            .with_body(json!({"status": "ready"}).to_string())
+            .create();
+        let activate = server
+            .mock("POST", "/v1/apps/company/stages/prod/activate")
+            .match_header("authorization", "Bearer token-secret")
+            .with_status(200)
+            .with_body(json!({"active_deploy_id": "d-1"}).to_string())
+            .create();
+        let target = DeployTarget {
+            id: "company".into(),
+            slug: None,
+        };
+        let args = test_args();
+        let client = http::client(Duration::from_secs(15)).unwrap();
+
+        deploy_static(
+            &args,
+            dir.path(),
+            &target,
+            &mut auth,
+            &server.url(),
+            &client,
+        )
+        .expect("deploy token works");
+        no_lookup.assert();
+        create.assert();
+        finalize.assert();
+        activate.assert();
+    }
+
+    #[test]
+    fn oidc_target_rejects_an_environment_substitution() {
+        let error = oidc_target(
+            api::DeployGrant {
+                grant: "grant-secret".into(),
+                expires_at: "2026-07-27T05:30:00Z".into(),
+                app_id: "app-1".into(),
+                env: "staging".into(),
+            },
+            "prod",
+        )
+        .expect_err("environment mismatch");
+        let message = error.to_string();
+        assert!(message.contains("staging"), "{message}");
+        assert!(message.contains("prod"), "{message}");
+        assert!(!message.contains("grant-secret"), "{message}");
     }
 }

--- a/src/commands/app/deploy.rs
+++ b/src/commands/app/deploy.rs
@@ -99,10 +99,14 @@ pub struct DeployArgs {
 }
 
 pub fn run(args: DeployArgs) -> Result<()> {
-    let dir = args
-        .dir
-        .clone()
-        .unwrap_or_else(|| std::env::current_dir().expect("cwd"));
+    let dir = match args.dir.clone() {
+        Some(dir) => dir,
+        // Not unreachable in CI: a job whose workspace is removed mid-run
+        // leaves the process with no cwd. Panicking there exits 101 with a
+        // backtrace instead of saying what to pass.
+        None => std::env::current_dir()
+            .context("could not read the current directory — pass --dir explicitly")?,
+    };
     if !dir.is_dir() {
         return Err(anyhow!("{} is not a directory", dir.display()));
     }
@@ -114,7 +118,7 @@ pub fn run(args: DeployArgs) -> Result<()> {
     };
 
     let apps_base = resolve_base(ENV_APPS_API_URL, DEFAULT_APPS_API_BASE);
-    let oidc_audience = deploy_auth::resolve_oidc_audience(|name| std::env::var(name).ok());
+    let oidc_audience = deploy_auth::resolve_oidc_audience(|name| std::env::var(name).ok())?;
     let client = http::client(Duration::from_secs(15))?;
 
     let selected = deploy_auth::select_deploy_auth(
@@ -613,7 +617,12 @@ fn upload_one(client: &Client, target: &api::UploadTarget, path: &Path) -> Resul
     for (k, v) in &target.headers {
         req = req.header(k.as_str(), v.as_str());
     }
-    let resp = req.send()?;
+    // `reqwest::Error` renders the URL it failed on, and this one carries a
+    // live signature. In a CI log that is a usable write credential until it
+    // expires, so strip the URL before the error can reach stderr.
+    let resp = req
+        .send()
+        .map_err(|e| anyhow!("presigned PUT failed: {}", e.without_url()))?;
     let status = resp.status();
     if !status.is_success() {
         let body = http::read_capped(resp).unwrap_or_default();

--- a/src/commands/app/deploy_auth.rs
+++ b/src/commands/app/deploy_auth.rs
@@ -1,0 +1,647 @@
+//! Credential selection for app deploys. Deploy grants and deploy tokens
+//! deliberately never enter the persisted OAuth credential lifecycle.
+
+use std::fmt;
+
+use anyhow::{Context, Result, anyhow};
+use reqwest::blocking::Client;
+use serde::Deserialize;
+use url::Url;
+
+use crate::api::{self, ApiError, DeployGrantError, DeployGrantInput};
+use crate::commands::session_expired;
+use crate::credentials::{self, Credentials};
+use crate::http;
+
+pub(super) const ENV_DEPLOY_TOKEN: &str = "MIRRORSTACK_TOKEN";
+const ENV_ACTIONS_ID_TOKEN_REQUEST_URL: &str = "ACTIONS_ID_TOKEN_REQUEST_URL";
+const ENV_ACTIONS_ID_TOKEN_REQUEST_TOKEN: &str = "ACTIONS_ID_TOKEN_REQUEST_TOKEN";
+const ENV_GITHUB_ACTIONS: &str = "GITHUB_ACTIONS";
+
+pub(super) enum DeployAuth {
+    User(Credentials),
+    Grant(String),
+    Token(String),
+}
+
+impl fmt::Debug for DeployAuth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::User(_) => f.write_str("User(<redacted>)"),
+            Self::Grant(_) => f.write_str("Grant(<redacted>)"),
+            Self::Token(_) => f.write_str("Token(<redacted>)"),
+        }
+    }
+}
+
+impl DeployAuth {
+    /// OAuth sessions retain their one refresh attempt. App-bound deploy
+    /// credentials have no refresh path and are called exactly once.
+    pub(super) fn with_retry<T>(
+        &mut self,
+        mut call: impl FnMut(&str) -> Result<T, ApiError>,
+    ) -> Result<T, ApiError> {
+        match self {
+            Self::User(creds) => credentials::with_refresh_retry(creds, call),
+            Self::Grant(grant) | Self::Token(grant) => call(grant),
+        }
+    }
+
+    pub(super) fn deploy_error(&self, error: ApiError) -> anyhow::Error {
+        match self {
+            Self::Grant(secret) => bound_credential_error(secret, true, error),
+            Self::Token(secret) => bound_credential_error(secret, false, error),
+            Self::User(_) => match error {
+                ApiError::Unauthenticated => session_expired(),
+                ApiError::Server { code, message, .. } => anyhow!("{code}: {message}"),
+                other => other.into(),
+            },
+        }
+    }
+}
+
+fn bound_credential_error(secret: &str, grant: bool, error: ApiError) -> anyhow::Error {
+    match error {
+        ApiError::Unauthenticated if grant => anyhow!(
+            "the OIDC deploy grant expired or was revoked; re-run the workflow to obtain a new grant"
+        ),
+        ApiError::Unauthenticated => anyhow!(
+            "MIRRORSTACK_TOKEN was rejected; it may be revoked or bound to a different app or environment. Create a new deploy token in the app's deployment settings"
+        ),
+        ApiError::Server { code, message, .. } => {
+            anyhow!("{}: {}", redact(&code, secret), redact(&message, secret))
+        }
+        ApiError::Unexpected { status, body } => anyhow!(
+            "api: unexpected response {status}: {}",
+            redact(&body, secret)
+        ),
+        ApiError::Http(error) => anyhow!("api: HTTP error: {error}"),
+        ApiError::Decode(error) => anyhow!("api: decode response: {error}"),
+    }
+}
+
+fn redact(value: &str, secret: &str) -> String {
+    if secret.is_empty() {
+        value.to_string()
+    } else {
+        value.replace(secret, "<redacted>")
+    }
+}
+
+pub(super) enum SelectedDeployAuth {
+    Oidc {
+        request_url: String,
+        request_token: String,
+    },
+    Ready(DeployAuth),
+}
+
+impl fmt::Debug for SelectedDeployAuth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Oidc { .. } => f.write_str("Oidc(<redacted>)"),
+            Self::Ready(auth) => f.debug_tuple("Ready").field(auth).finish(),
+        }
+    }
+}
+
+/// Resolve credential precedence without doing network I/O. In particular,
+/// choosing OIDC returns only its runtime inputs, so an exchange failure
+/// has no code path back to either the env token or stored credentials.
+pub(super) fn select_deploy_auth(
+    oidc: bool,
+    mut env_lookup: impl FnMut(&str) -> Option<String>,
+    credential_loader: impl FnOnce() -> Result<Credentials>,
+) -> Result<SelectedDeployAuth> {
+    if oidc {
+        let request_url = nonempty_env(&mut env_lookup, ENV_ACTIONS_ID_TOKEN_REQUEST_URL);
+        let request_token = nonempty_env(&mut env_lookup, ENV_ACTIONS_ID_TOKEN_REQUEST_TOKEN);
+        if request_url.is_none() || request_token.is_none() {
+            let mut missing = Vec::new();
+            if request_url.is_none() {
+                missing.push(ENV_ACTIONS_ID_TOKEN_REQUEST_URL);
+            }
+            if request_token.is_none() {
+                missing.push(ENV_ACTIONS_ID_TOKEN_REQUEST_TOKEN);
+            }
+            let outside_actions = request_url.is_none()
+                && request_token.is_none()
+                && nonempty_env(&mut env_lookup, ENV_GITHUB_ACTIONS).is_none();
+            let mut message = format!(
+                "--oidc requires {}. Add this to the workflow job:\npermissions:\n  id-token: write",
+                missing.join(" and ")
+            );
+            if outside_actions {
+                message.push_str("\n--oidc only works inside GitHub Actions.");
+            }
+            return Err(anyhow!(message));
+        }
+        return Ok(SelectedDeployAuth::Oidc {
+            request_url: request_url.expect("checked"),
+            request_token: request_token.expect("checked"),
+        });
+    }
+
+    if let Some(token) = nonempty_env(&mut env_lookup, ENV_DEPLOY_TOKEN) {
+        return Ok(SelectedDeployAuth::Ready(DeployAuth::Token(token)));
+    }
+
+    Ok(SelectedDeployAuth::Ready(DeployAuth::User(
+        credential_loader()?,
+    )))
+}
+
+fn nonempty_env(env_lookup: &mut impl FnMut(&str) -> Option<String>, name: &str) -> Option<String> {
+    env_lookup(name).filter(|value| !value.trim().is_empty())
+}
+
+#[derive(Deserialize)]
+struct ActionsIdToken {
+    value: String,
+}
+
+pub(super) fn request_actions_id_token(
+    client: &Client,
+    request_url: &str,
+    request_token: &str,
+) -> Result<String> {
+    let mut url = Url::parse(request_url).context("invalid ACTIONS_ID_TOKEN_REQUEST_URL")?;
+    url.query_pairs_mut().append_pair("audience", "mirrorstack");
+
+    let resp = client
+        .get(url)
+        .bearer_auth(request_token)
+        .header("Accept", "application/json")
+        .send()
+        .map_err(|_| anyhow!("GitHub Actions OIDC token request failed"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(anyhow!(
+            "GitHub Actions OIDC token request failed with HTTP {}; verify the workflow job has `permissions:\n  id-token: write`",
+            status.as_u16()
+        ));
+    }
+    let body = http::read_capped(resp).context("read GitHub Actions OIDC response")?;
+    let response: ActionsIdToken =
+        serde_json::from_slice(&body).context("decode GitHub Actions OIDC response")?;
+    if response.value.trim().is_empty() {
+        return Err(anyhow!(
+            "GitHub Actions OIDC token response did not contain a token"
+        ));
+    }
+    Ok(response.value)
+}
+
+pub(super) fn exchange_oidc(
+    client: &Client,
+    apps_base: &str,
+    request_url: &str,
+    request_token: &str,
+    app: &str,
+    env: &str,
+) -> Result<api::DeployGrant> {
+    let jwt = request_actions_id_token(client, request_url, request_token)?;
+    api::exchange_deploy_grant(
+        client,
+        apps_base,
+        &DeployGrantInput {
+            token: &jwt,
+            app,
+            env,
+        },
+    )
+    .map_err(|error| exchange_error(app, &jwt, error))
+}
+
+fn exchange_error(app: &str, jwt: &str, error: DeployGrantError) -> anyhow::Error {
+    match error {
+        DeployGrantError::BindingPending {
+            sub, approval_url, ..
+        } => anyhow!(
+            "This repo is not yet authorised to deploy `{app}`. A pending binding was created for `{}`. Approve it at {}, then re-run.",
+            redact(&sub, jwt),
+            redact(&approval_url, jwt)
+        ),
+        DeployGrantError::BindingRevoked { .. } => anyhow!(
+            "The deploy binding for `{app}` was revoked and must be re-approved in the app's deployment settings."
+        ),
+        DeployGrantError::Server { code, message, .. } => anyhow!(
+            "OIDC deploy-grant exchange failed: {}: {}",
+            redact(&code, jwt),
+            redact(&message, jwt)
+        ),
+        DeployGrantError::Unexpected { status } => {
+            anyhow!("OIDC deploy-grant exchange returned HTTP {status}")
+        }
+        DeployGrantError::Http(_) => anyhow!("OIDC deploy-grant request failed"),
+        DeployGrantError::Io(_) => anyhow!("OIDC deploy-grant response could not be read"),
+        DeployGrantError::Decode(_) => anyhow!("OIDC deploy-grant response was invalid"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::cell::Cell;
+    use std::ffi::OsString;
+    use std::fs;
+    use std::path::Path;
+    use std::time::{Duration, SystemTime};
+
+    use mockito::{Matcher, Server};
+    use serde_json::json;
+
+    fn stored() -> Credentials {
+        Credentials {
+            access_token: "stored-access".into(),
+            refresh_token: "stored-refresh".into(),
+            expires_at: SystemTime::now() + Duration::from_secs(900),
+        }
+    }
+
+    #[test]
+    fn credential_precedence_and_empty_token() {
+        let loads = Cell::new(0);
+        let selected = select_deploy_auth(
+            true,
+            |name| match name {
+                ENV_ACTIONS_ID_TOKEN_REQUEST_URL => Some("https://actions.example/token".into()),
+                ENV_ACTIONS_ID_TOKEN_REQUEST_TOKEN => Some("runtime-secret".into()),
+                ENV_DEPLOY_TOKEN => Some("deploy-secret".into()),
+                _ => None,
+            },
+            || {
+                loads.set(loads.get() + 1);
+                Ok(stored())
+            },
+        )
+        .expect("oidc selected");
+        assert!(matches!(selected, SelectedDeployAuth::Oidc { .. }));
+        assert_eq!(loads.get(), 0, "OIDC must not load stored credentials");
+
+        let selected = select_deploy_auth(
+            false,
+            |name| (name == ENV_DEPLOY_TOKEN).then(|| "deploy-secret".into()),
+            || {
+                loads.set(loads.get() + 1);
+                Ok(stored())
+            },
+        )
+        .expect("token selected");
+        assert!(matches!(
+            selected,
+            SelectedDeployAuth::Ready(DeployAuth::Token(_))
+        ));
+        assert_eq!(loads.get(), 0, "env token must not load stored credentials");
+
+        let selected = select_deploy_auth(
+            false,
+            |name| (name == ENV_DEPLOY_TOKEN).then(|| " \t ".into()),
+            || {
+                loads.set(loads.get() + 1);
+                Ok(stored())
+            },
+        )
+        .expect("stored selected");
+        assert!(matches!(
+            selected,
+            SelectedDeployAuth::Ready(DeployAuth::User(_))
+        ));
+        assert_eq!(loads.get(), 1);
+    }
+
+    #[test]
+    fn grant_and_token_never_retry_a_rejected_call() {
+        for mut auth in [
+            DeployAuth::Grant("grant-secret".into()),
+            DeployAuth::Token("token-secret".into()),
+        ] {
+            let mut attempts = 0;
+            let error = auth
+                .with_retry::<()>(|_| {
+                    attempts += 1;
+                    Err(ApiError::Unauthenticated)
+                })
+                .expect_err("rejected");
+            assert!(matches!(error, ApiError::Unauthenticated));
+            assert_eq!(attempts, 1);
+
+            let message = auth.deploy_error(error).to_string();
+            assert!(!message.contains("mirrorstack login"), "{message}");
+            match auth {
+                DeployAuth::Grant(_) => assert!(message.contains("re-run"), "{message}"),
+                DeployAuth::Token(_) => {
+                    assert!(message.contains("deployment settings"), "{message}")
+                }
+                DeployAuth::User(_) => unreachable!(),
+            }
+        }
+    }
+
+    #[test]
+    fn presented_credentials_are_redacted_from_server_errors() {
+        let grant = DeployAuth::Grant("grant-secret".into());
+        let message = grant
+            .deploy_error(ApiError::Unexpected {
+                status: 500,
+                body: "backend echoed grant-secret".into(),
+            })
+            .to_string();
+        assert!(!message.contains("grant-secret"), "{message}");
+        assert!(message.contains("<redacted>"), "{message}");
+
+        let token = DeployAuth::Token("token-secret".into());
+        let message = token
+            .deploy_error(ApiError::Server {
+                status: 403,
+                code: "token-secret".into(),
+                message: "backend echoed token-secret".into(),
+            })
+            .to_string();
+        assert!(!message.contains("token-secret"), "{message}");
+
+        let message = exchange_error(
+            "company",
+            "github-jwt",
+            DeployGrantError::Server {
+                status: 401,
+                code: "invalid_token".into(),
+                message: "backend echoed github-jwt".into(),
+            },
+        )
+        .to_string();
+        assert!(!message.contains("github-jwt"), "{message}");
+
+        let message = exchange_error(
+            "company",
+            "github-jwt",
+            DeployGrantError::BindingRevoked {
+                message: "revoked".into(),
+            },
+        )
+        .to_string();
+        assert!(message.contains("revoked"), "{message}");
+        assert!(message.contains("re-approved"), "{message}");
+        assert!(message.contains("deployment settings"), "{message}");
+    }
+
+    #[test]
+    fn missing_oidc_runtime_fails_before_http() {
+        let error = select_deploy_auth(
+            true,
+            |name| {
+                (name == ENV_ACTIONS_ID_TOKEN_REQUEST_URL)
+                    .then(|| "https://actions.invalid/must-not-be-called".into())
+            },
+            || Ok(stored()),
+        )
+        .expect_err("missing runtime token");
+        let message = error.to_string();
+        assert!(message.contains("permissions:"), "{message}");
+        assert!(message.contains("id-token: write"), "{message}");
+        assert!(
+            message.contains(ENV_ACTIONS_ID_TOKEN_REQUEST_TOKEN),
+            "{message}"
+        );
+
+        let error = select_deploy_auth(true, |_| None, || Ok(stored()))
+            .expect_err("outside GitHub Actions");
+        assert!(
+            error
+                .to_string()
+                .contains("--oidc only works inside GitHub Actions"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn oidc_requests_and_binding_diagnostic_match_contract_without_fallback() {
+        let mut actions = Server::new();
+        let actions_request = actions
+            .mock("GET", "/token")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("existing".into(), "1".into()),
+                Matcher::UrlEncoded("audience".into(), "mirrorstack".into()),
+            ]))
+            .match_header("authorization", "Bearer runtime-bearer")
+            .with_status(200)
+            .with_body(json!({"value": "github-jwt"}).to_string())
+            .create();
+
+        let sub = "repo:org/repo:ref:refs/heads/main";
+        let approval_url = "https://apps.mirrorstack.ai/apps/app-1/settings/deployment";
+        let mut apps = Server::new();
+        let exchange = apps
+            .mock("POST", "/v1/oidc/deploy-grant")
+            .match_header("authorization", Matcher::Missing)
+            .match_body(Matcher::Json(json!({
+                "token": "github-jwt",
+                "app": "company",
+                "env": "prod"
+            })))
+            .with_status(403)
+            .with_body(
+                json!({
+                    "code": "binding_pending",
+                    "message": "approval required",
+                    "sub": sub,
+                    "approval_url": approval_url
+                })
+                .to_string(),
+            )
+            .create();
+        let stored_bearer = apps
+            .mock("GET", "/v1/apps/company")
+            .match_header("authorization", "Bearer stored-access")
+            .expect(0)
+            .create();
+
+        let loads = Cell::new(0);
+        let selected = select_deploy_auth(
+            true,
+            |name| match name {
+                ENV_ACTIONS_ID_TOKEN_REQUEST_URL => {
+                    Some(format!("{}/token?existing=1", actions.url()))
+                }
+                ENV_ACTIONS_ID_TOKEN_REQUEST_TOKEN => Some("runtime-bearer".into()),
+                ENV_DEPLOY_TOKEN => Some("deploy-secret".into()),
+                _ => None,
+            },
+            || {
+                loads.set(loads.get() + 1);
+                Ok(stored())
+            },
+        )
+        .expect("OIDC selected");
+        let SelectedDeployAuth::Oidc {
+            request_url,
+            request_token,
+        } = selected
+        else {
+            panic!("OIDC must win");
+        };
+
+        let error = exchange_oidc(
+            &http::client(Duration::from_secs(15)).unwrap(),
+            &apps.url(),
+            &request_url,
+            &request_token,
+            "company",
+            "prod",
+        )
+        .expect_err("binding pending");
+        let message = error.to_string();
+        assert!(message.contains(sub), "{message}");
+        assert!(message.contains(approval_url), "{message}");
+        assert!(!message.contains("401"), "{message}");
+        assert!(!message.contains("mirrorstack login"), "{message}");
+        assert_eq!(loads.get(), 0, "failed exchange must not load OAuth");
+        actions_request.assert();
+        exchange.assert();
+        stored_bearer.assert();
+    }
+
+    #[test]
+    fn grant_and_token_http_401_are_single_attempt_and_actionable() {
+        let mut server = Server::new();
+        let grant_call = server
+            .mock("POST", "/v1/apps/app-1/deploys")
+            .match_header("authorization", "Bearer grant-secret")
+            .with_status(401)
+            .expect(1)
+            .create();
+        let token_call = server
+            .mock("POST", "/v1/apps/app-1/deploys")
+            .match_header("authorization", "Bearer token-secret")
+            .with_status(401)
+            .expect(1)
+            .create();
+        let client = http::client(Duration::from_secs(15)).unwrap();
+        let input = api::CreateAppDeployInput {
+            env: "prod",
+            note: None,
+            runtime: None,
+            files: &[],
+        };
+
+        let mut grant = DeployAuth::Grant("grant-secret".into());
+        let error = grant
+            .with_retry(|credential| {
+                api::create_app_deploy(&client, &server.url(), credential, "app-1", &input)
+            })
+            .expect_err("grant rejected");
+        let message = grant.deploy_error(error).to_string();
+        assert!(message.contains("expired or was revoked"), "{message}");
+        assert!(message.contains("re-run"), "{message}");
+
+        let mut token = DeployAuth::Token("token-secret".into());
+        let error = token
+            .with_retry(|credential| {
+                api::create_app_deploy(&client, &server.url(), credential, "app-1", &input)
+            })
+            .expect_err("token rejected");
+        let message = token.deploy_error(error).to_string();
+        assert!(message.contains("MIRRORSTACK_TOKEN"), "{message}");
+        assert!(message.contains("deployment settings"), "{message}");
+        grant_call.assert();
+        token_call.assert();
+    }
+
+    struct EnvRestore {
+        name: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.name, value),
+                    None => std::env::remove_var(self.name),
+                }
+            }
+        }
+    }
+
+    fn redirect_config(path: &Path) -> EnvRestore {
+        #[cfg(target_os = "macos")]
+        let name = "HOME";
+        #[cfg(target_os = "windows")]
+        let name = "APPDATA";
+        #[cfg(all(unix, not(target_os = "macos")))]
+        let name = "XDG_CONFIG_HOME";
+        let previous = std::env::var_os(name);
+        unsafe { std::env::set_var(name, path) };
+        EnvRestore { name, previous }
+    }
+
+    #[test]
+    fn exchanged_grant_never_changes_credentials_file() {
+        let _env = credentials::TEST_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let config = tempfile::tempdir().expect("config tempdir");
+        let _restore = redirect_config(config.path());
+
+        let mut actions = Server::new();
+        let actions_request = actions
+            .mock("GET", "/token")
+            .match_query(Matcher::UrlEncoded("audience".into(), "mirrorstack".into()))
+            .match_header("authorization", "Bearer runtime-bearer")
+            .with_status(200)
+            .with_body(json!({"value": "github-jwt"}).to_string())
+            .expect(2)
+            .create();
+        let mut apps = Server::new();
+        let exchange = apps
+            .mock("POST", "/v1/oidc/deploy-grant")
+            .match_header("authorization", Matcher::Missing)
+            .with_status(200)
+            .with_body(
+                json!({
+                    "grant": "grant-secret",
+                    "expires_at": "2026-07-27T05:30:00Z",
+                    "app_id": "app-1",
+                    "env": "prod"
+                })
+                .to_string(),
+            )
+            .expect(2)
+            .create();
+        let client = http::client(Duration::from_secs(15)).unwrap();
+        let request_url = format!("{}/token", actions.url());
+
+        let grant = exchange_oidc(
+            &client,
+            &apps.url(),
+            &request_url,
+            "runtime-bearer",
+            "company",
+            "prod",
+        )
+        .expect("exchange without credential file");
+        assert_eq!(grant.grant, "grant-secret");
+        let credentials_path = credentials::path().expect("credentials path");
+        assert!(
+            !credentials_path.exists(),
+            "grant exchange created credentials.json"
+        );
+
+        fs::create_dir_all(credentials_path.parent().unwrap()).unwrap();
+        let original = b"{\"sentinel\":\"byte-identical\"}\n";
+        fs::write(&credentials_path, original).unwrap();
+        exchange_oidc(
+            &client,
+            &apps.url(),
+            &request_url,
+            "runtime-bearer",
+            "company",
+            "prod",
+        )
+        .expect("exchange with credential file");
+        assert_eq!(fs::read(&credentials_path).unwrap(), original);
+        actions_request.assert();
+        exchange.assert();
+    }
+}

--- a/src/commands/app/deploy_auth.rs
+++ b/src/commands/app/deploy_auth.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use url::Url;
 
 use crate::api::{self, ApiError, DeployGrantError, DeployGrantInput};
-use crate::commands::session_expired;
+use crate::commands::{DEFAULT_OIDC_AUDIENCE, ENV_OIDC_AUDIENCE, session_expired};
 use crate::credentials::{self, Credentials};
 use crate::http;
 
@@ -155,6 +155,10 @@ fn nonempty_env(env_lookup: &mut impl FnMut(&str) -> Option<String>, name: &str)
     env_lookup(name).filter(|value| !value.trim().is_empty())
 }
 
+pub(super) fn resolve_oidc_audience(mut env_lookup: impl FnMut(&str) -> Option<String>) -> String {
+    nonempty_env(&mut env_lookup, ENV_OIDC_AUDIENCE).unwrap_or_else(|| DEFAULT_OIDC_AUDIENCE.into())
+}
+
 #[derive(Deserialize)]
 struct ActionsIdToken {
     value: String,
@@ -164,9 +168,10 @@ pub(super) fn request_actions_id_token(
     client: &Client,
     request_url: &str,
     request_token: &str,
+    audience: &str,
 ) -> Result<String> {
     let mut url = Url::parse(request_url).context("invalid ACTIONS_ID_TOKEN_REQUEST_URL")?;
-    url.query_pairs_mut().append_pair("audience", "mirrorstack");
+    url.query_pairs_mut().append_pair("audience", audience);
 
     let resp = client
         .get(url)
@@ -197,10 +202,11 @@ pub(super) fn exchange_oidc(
     apps_base: &str,
     request_url: &str,
     request_token: &str,
+    audience: &str,
     app: &str,
     env: &str,
 ) -> Result<api::DeployGrant> {
-    let jwt = request_actions_id_token(client, request_url, request_token)?;
+    let jwt = request_actions_id_token(client, request_url, request_token, audience)?;
     api::exchange_deploy_grant(
         client,
         apps_base,
@@ -224,6 +230,12 @@ fn exchange_error(app: &str, jwt: &str, error: DeployGrantError) -> anyhow::Erro
         ),
         DeployGrantError::BindingRevoked { .. } => anyhow!(
             "The deploy binding for `{app}` was revoked and must be re-approved in the app's deployment settings."
+        ),
+        DeployGrantError::Server { code, message, .. } if code == "invalid_token" => anyhow!(
+            "OIDC deploy-grant exchange failed: {}: {}. Set {} to match the server's configured audience.",
+            redact(&code, jwt),
+            redact(&message, jwt),
+            ENV_OIDC_AUDIENCE
         ),
         DeployGrantError::Server { code, message, .. } => anyhow!(
             "OIDC deploy-grant exchange failed: {}: {}",
@@ -416,6 +428,60 @@ mod tests {
     }
 
     #[test]
+    fn oidc_audience_override_and_default_are_requested() {
+        for (configured, expected) in [
+            (Some("custom-aud"), "custom-aud"),
+            (None, DEFAULT_OIDC_AUDIENCE),
+        ] {
+            let audience = resolve_oidc_audience(|_| configured.map(str::to_owned));
+            let mut actions = Server::new();
+            let request = actions
+                .mock("GET", "/token")
+                .match_query(Matcher::UrlEncoded("audience".into(), expected.into()))
+                .match_header("authorization", "Bearer runtime-bearer")
+                .with_status(200)
+                .with_body(json!({"value": "github-jwt"}).to_string())
+                .create();
+
+            let jwt = request_actions_id_token(
+                &http::client(Duration::from_secs(15)).unwrap(),
+                &format!("{}/token", actions.url()),
+                "runtime-bearer",
+                &audience,
+            )
+            .expect("Actions ID token");
+            assert_eq!(jwt, "github-jwt");
+            request.assert();
+        }
+
+        for empty in ["", " \t "] {
+            assert_eq!(
+                resolve_oidc_audience(|_| Some(empty.into())),
+                DEFAULT_OIDC_AUDIENCE
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_token_diagnostic_names_audience_override() {
+        let message = exchange_error(
+            "company",
+            "github-jwt",
+            DeployGrantError::Server {
+                status: 401,
+                code: "invalid_token".into(),
+                message: "audience mismatch".into(),
+            },
+        )
+        .to_string();
+        assert!(
+            message.contains("invalid_token: audience mismatch"),
+            "{message}"
+        );
+        assert!(message.contains(ENV_OIDC_AUDIENCE), "{message}");
+    }
+
+    #[test]
     fn oidc_requests_and_binding_diagnostic_match_contract_without_fallback() {
         let mut actions = Server::new();
         let actions_request = actions
@@ -487,6 +553,7 @@ mod tests {
             &apps.url(),
             &request_url,
             &request_token,
+            DEFAULT_OIDC_AUDIENCE,
             "company",
             "prod",
         )
@@ -617,6 +684,7 @@ mod tests {
             &apps.url(),
             &request_url,
             "runtime-bearer",
+            DEFAULT_OIDC_AUDIENCE,
             "company",
             "prod",
         )
@@ -636,6 +704,7 @@ mod tests {
             &apps.url(),
             &request_url,
             "runtime-bearer",
+            DEFAULT_OIDC_AUDIENCE,
             "company",
             "prod",
         )

--- a/src/commands/app/deploy_auth.rs
+++ b/src/commands/app/deploy_auth.rs
@@ -155,8 +155,27 @@ fn nonempty_env(env_lookup: &mut impl FnMut(&str) -> Option<String>, name: &str)
     env_lookup(name).filter(|value| !value.trim().is_empty())
 }
 
-pub(super) fn resolve_oidc_audience(mut env_lookup: impl FnMut(&str) -> Option<String>) -> String {
-    nonempty_env(&mut env_lookup, ENV_OIDC_AUDIENCE).unwrap_or_else(|| DEFAULT_OIDC_AUDIENCE.into())
+/// The audience is what stops a token minted for someone else being replayed
+/// at the exchange, so an override that erases that separation is refused here
+/// rather than silently requested from GitHub. The two dangerous values are
+/// exactly the ones someone might reach for: GitHub's own default audience
+/// (`https://github.com/<owner>`, which every repo under that owner gets for
+/// free) and the AWS one.
+pub(super) fn resolve_oidc_audience(
+    mut env_lookup: impl FnMut(&str) -> Option<String>,
+) -> Result<String> {
+    let audience = nonempty_env(&mut env_lookup, ENV_OIDC_AUDIENCE)
+        .unwrap_or_else(|| DEFAULT_OIDC_AUDIENCE.into());
+    let lowered = audience.to_ascii_lowercase();
+    if lowered == "sts.amazonaws.com" || lowered.starts_with("https://github.com/") {
+        return Err(anyhow!(
+            "{ENV_OIDC_AUDIENCE}={audience} is not MirrorStack-specific — \
+             GitHub's default audience and sts.amazonaws.com are shared with \
+             other consumers, so a token minted for them could be replayed. \
+             Unset it to use the default `{DEFAULT_OIDC_AUDIENCE}`."
+        ));
+    }
+    Ok(audience)
 }
 
 #[derive(Deserialize)]
@@ -433,7 +452,7 @@ mod tests {
             (Some("custom-aud"), "custom-aud"),
             (None, DEFAULT_OIDC_AUDIENCE),
         ] {
-            let audience = resolve_oidc_audience(|_| configured.map(str::to_owned));
+            let audience = resolve_oidc_audience(|_| configured.map(str::to_owned)).unwrap();
             let mut actions = Server::new();
             let request = actions
                 .mock("GET", "/token")
@@ -456,9 +475,34 @@ mod tests {
 
         for empty in ["", " \t "] {
             assert_eq!(
-                resolve_oidc_audience(|_| Some(empty.into())),
+                resolve_oidc_audience(|_| Some(empty.into())).unwrap(),
                 DEFAULT_OIDC_AUDIENCE
             );
+        }
+    }
+
+    /// An audience shared with other consumers is not domain separation: a
+    /// token minted for GitHub's default audience or for AWS could be replayed
+    /// at the exchange. Refuse before asking GitHub to mint one.
+    #[test]
+    fn oidc_audience_rejects_non_separated_overrides() {
+        for bad in [
+            "sts.amazonaws.com",
+            "https://github.com/mirrorstack-ai",
+            "HTTPS://GitHub.com/acme",
+        ] {
+            let error = resolve_oidc_audience(|_| Some(bad.into()))
+                .expect_err("expected rejection")
+                .to_string();
+            assert!(error.contains(ENV_OIDC_AUDIENCE), "{error}");
+            assert!(error.contains(DEFAULT_OIDC_AUDIENCE), "{error}");
+        }
+        for good in [
+            "mirrorstack",
+            "mirrorstack-staging",
+            "https://api.mirrorstack.ai",
+        ] {
+            assert_eq!(resolve_oidc_audience(|_| Some(good.into())).unwrap(), good);
         }
     }
 

--- a/src/commands/app/mod.rs
+++ b/src/commands/app/mod.rs
@@ -19,6 +19,7 @@ use super::{
 };
 
 mod deploy;
+mod deploy_auth;
 mod ssr;
 
 #[derive(Args)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,10 +34,16 @@ pub(crate) const DEFAULT_WEB_BASE: &str = "https://account.mirrorstack.ai";
 /// Override with `MIRRORSTACK_DISPATCH_URL`.
 pub(crate) const DEFAULT_DISPATCH_BASE: &str = "https://api.mirrorstack.ai/dispatch";
 
+/// Default GitHub Actions OIDC audience. Override with
+/// `MIRRORSTACK_OIDC_AUDIENCE`.
+pub(crate) const DEFAULT_OIDC_AUDIENCE: &str = "mirrorstack";
+
 pub(crate) const ENV_API_URL: &str = "MIRRORSTACK_API_URL";
 pub(crate) const ENV_APPS_API_URL: &str = "MIRRORSTACK_APPS_API_URL";
 pub(crate) const ENV_WEB_URL: &str = "MIRRORSTACK_WEB_URL";
 pub(crate) const ENV_DISPATCH_URL: &str = "MIRRORSTACK_DISPATCH_URL";
+/// GitHub Actions OIDC audience used for app deploy-grant exchange.
+pub(crate) const ENV_OIDC_AUDIENCE: &str = "MIRRORSTACK_OIDC_AUDIENCE";
 
 /// Look up a base URL from `env_var`, falling back to `default` when unset.
 pub(crate) fn resolve_base(env_var: &str, default: &str) -> String {

--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -18,6 +18,11 @@ use crate::api::{self, ApiError};
 use crate::commands::{DEFAULT_API_BASE, ENV_API_URL, resolve_base, warn_prefix};
 use crate::http;
 
+/// Process environment is global, so tests redirecting the config path or
+/// API base share one lock across modules.
+#[cfg(test)]
+pub(crate) static TEST_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Local access-token lifetime re-derived on every refresh. The platform's
 /// `TokenConfig` mints 15-minute access tokens; the refresh response's
 /// `expires_at` is informational only, so we recompute the TTL locally to

--- a/src/credentials/tests.rs
+++ b/src/credentials/tests.rs
@@ -28,6 +28,9 @@ fn with_temp_config_dir() -> tempfile::TempDir {
 /// `serial_test` crate.
 #[test]
 fn credentials_lifecycle() {
+    let _env = TEST_ENV_MUTEX
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let _g = with_temp_config_dir();
 
     // load() before save() returns NotFound.


### PR DESCRIPTION
Closes #68

Implements CONTRACT.md §4 of the deploy-grant contract (core-v2#311): CI-usable
credentials for `mirrorstack apps web deploy`.

## What lands

- **`--oidc`** — mints the GitHub Actions OIDC JWT from
  `ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN` with `audience=mirrorstack`, exchanges it at the
  public `POST /v1/oidc/deploy-grant` (§1), and uses the returned grant as the bearer for
  create → finalize → activate (§2).
- **`MIRRORSTACK_TOKEN`** — long-lived deploy token for non-GitHub CI, laptops and agents.
  No browser, no credentials file.
- **Precedence** `--oidc` → `MIRRORSTACK_TOKEN` → stored OAuth credentials, resolved by a
  pure `select_deploy_auth()` that does no network I/O. An explicit `--oidc` has **no code
  path back** to the env token or to stored credentials: choosing OIDC returns only the
  runtime inputs, so an exchange failure can only fail the command.
- **`DeployAuth`** (`User` / `Grant` / `Token`) replaces the bare `Credentials` threaded
  through the deploy functions. `User` keeps today's refresh-and-retry-once behaviour;
  `Grant`/`Token` call exactly once — there is nothing to refresh, so a 401 surfaces as an
  actionable message rather than a retry.

## Diagnostics (the point of the feature)

| Failure | Message |
|---|---|
| `binding_pending` 403 | names the `sub` and the `approval_url` from the response body |
| `binding_revoked` 403 | says it was revoked and must be re-approved |
| `ACTIONS_ID_TOKEN_REQUEST_*` absent | names `permissions: id-token: write`, before any HTTP call; adds "only works inside GitHub Actions" when `GITHUB_ACTIONS` is also unset |
| 401 under a grant | grant expired/revoked — re-run (no login hint; there is no interactive login in CI) |
| 401 under a token | token revoked or bound to a different app/env |

## Security

- The JWT, the grant and `MIRRORSTACK_TOKEN` are never logged or printed —
  `Debug` is hand-written on every type that carries them and renders `<redacted>`.
- The grant is memory-only. `credentials::save` is unreachable from the grant/token paths;
  a test asserts `credentials.json` is neither created nor modified by an exchange.

## App resolution — behaviour change worth reviewing

`run()` resolved `--app` through `GET /v1/apps/{ref}` to get `app.id` + `app.slug`.
Contract §2 makes every non-deploy endpoint reject a deploy principal, so that lookup would
403 under a grant or token. Therefore:

- **user** auth: unchanged, id and slug both known;
- **grant**: `app_id` comes from the exchange response (the server already resolved the ref),
  and a returned `env` that differs from `--env` aborts the deploy;
- **token**: `--app` is passed through as the path segment; the server enforces the binding.

Where the slug is unknown the display label falls back to the `--app` ref and the
`url: https://<slug>.mirrorstack.app` line is omitted rather than fabricated from a UUID.

## One cross-repo assumption to confirm

The exchange is posted to the **apps** base — `MIRRORSTACK_APPS_API_URL` /
`https://api.mirrorstack.ai/apps` + `/v1/oidc/deploy-grant` — on the assumption the endpoint is
served by the applications service, alongside the deploy endpoints it mints credentials for.
The contract fixes the path but not the service. If api-platform mounts it on the account
service instead, this is a one-line change in `exchange_deploy_grant`.

## Validation

```
cargo fmt --all -- --check
RUSTFLAGS=-D warnings cargo clippy --all-targets --all-features
cargo test --all-features --no-fail-fast
```
