### PR TITLE
feat: mirrorstack module capabilities + dev-boot contribution check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +30,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -90,10 +110,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -120,10 +161,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -190,7 +243,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -334,7 +387,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -342,6 +395,15 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -363,6 +425,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -388,6 +461,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,12 +484,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -532,7 +632,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -540,6 +640,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -846,6 +951,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a77951c56b6a0af03c22af6953d6ffcfba9403c765578921f3f1089b999db6"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c2e64f341a1d6a15d2daa3c967e48921cf15b9c7f23a9899e8b63c7f7c4199"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e097778f3e9c6a33862077dbf07aca0360d0b18d2a7abc323da132df49ee83"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +1069,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +1109,7 @@ dependencies = [
  "dotenvy",
  "futures-util",
  "indicatif",
+ "jsonschema",
  "mockito",
  "open",
  "rand 0.9.4",
@@ -993,6 +1163,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1289,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -1114,7 +1368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1279,6 +1533,43 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "referencing"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b772e96f8eb6badd4eb10fbc08b8a98244c09b4af37e72e8fa612c854604b870"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.0",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -1469,7 +1760,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1578,6 +1869,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +1900,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1611,7 +1934,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1653,7 +1976,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1664,7 +1987,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1716,7 +2039,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1861,6 +2184,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,10 +2244,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "want"
@@ -1995,7 +2340,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2287,7 +2632,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2303,7 +2648,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2370,7 +2715,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2391,7 +2736,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2411,7 +2756,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2451,7 +2796,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ dialoguer = { version = "0.11", default-features = false }
 console = "0.15"
 indicatif = "0.17"
 ctrlc = "3"
+jsonschema = { version = "0.49.2", default-features = false }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "sync", "net", "io-util"] }
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ mirrorstack logout             # Revoke the current session and wipe local crede
 mirrorstack whoami             # Print the currently signed-in user
 mirrorstack app module init    # Register a new module on the platform
 mirrorstack app web deploy     # Deploy a static build directory to app hosting
+mirrorstack module capabilities         # Which host slots exist, who fills them, what is broken
+mirrorstack module capabilities --json  # …the same index, machine-readable
+mirrorstack module capabilities --app @me/my-app  # …resolved against the app's installed versions
 mirrorstack --help             # Show help
 mirrorstack --version          # Show CLI version
 ```

--- a/src/api.rs
+++ b/src/api.rs
@@ -592,6 +592,60 @@ pub fn get_app(
     Err(unexpected_body_error(resp))
 }
 
+/// One module installed into an app. `manifest` is the manifest FROZEN at the
+/// installed version — the same document the runtime authorizes against — so
+/// it is what capability resolution must read rather than local source.
+/// Absent for a dev-mount install (no pinned version) and for a pinned version
+/// the platform recorded without one.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppInstall {
+    pub module_id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub slug: String,
+    #[serde(default)]
+    pub installed_version: String,
+    #[serde(default)]
+    pub manifest: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct AppInstallList {
+    installs: Vec<AppInstall>,
+}
+
+/// GET /v1/apps/{appId}/installs — every module installed into the app, with
+/// the manifest frozen at its installed version. `app_id` must be the app
+/// UUID: the handler resolves the per-app tenant schema from it, so a slug
+/// 404s — resolve one with [`get_app`] first. Member-scoped.
+pub fn list_app_installs(
+    http: &Client,
+    apps_base: &str,
+    access_token: &str,
+    app_id: &str,
+) -> Result<Vec<AppInstall>, ApiError> {
+    let endpoint = format!(
+        "{}/v1/apps/{}/installs",
+        apps_base.trim_end_matches('/'),
+        app_id
+    );
+    let resp = http
+        .get(&endpoint)
+        .bearer_auth(access_token)
+        .header("Accept", "application/json")
+        .send()?;
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp.json::<AppInstallList>()?.installs);
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(ApiError::Unauthenticated);
+    }
+    Err(unexpected_body_error(resp))
+}
+
 /// One file of an app deploy's manifest, as POSTed to the platform.
 #[derive(Debug, Serialize)]
 pub struct DeployFile<'a> {
@@ -1190,6 +1244,34 @@ mod tests {
 
     use mockito::Server;
     use serde_json::json;
+
+    #[test]
+    fn list_app_installs_preserves_manifest() {
+        let mut server = Server::new();
+        let _m = server.mock("GET", "/v1/apps/app-id/installs")
+            .match_header("authorization", "Bearer AT")
+            .with_status(200)
+            .with_body(r#"{"installs":[{"moduleId":"m1","slug":"core","installedVersion":"1.2.3","manifest":{"provides":[{"key":"x"}]}}]}"#)
+            .create();
+        let installs = list_app_installs(&test_client(), &server.url(), "AT", "app-id").unwrap();
+        assert_eq!(
+            installs[0].manifest.as_ref().unwrap()["provides"][0]["key"],
+            "x"
+        );
+    }
+
+    #[test]
+    fn list_app_installs_401_is_unauthenticated() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("GET", "/v1/apps/app-id/installs")
+            .with_status(401)
+            .create();
+        assert!(matches!(
+            list_app_installs(&test_client(), &server.url(), "bad", "app-id"),
+            Err(ApiError::Unauthenticated)
+        ));
+    }
 
     fn test_client() -> Client {
         http::client(Duration::from_secs(15)).expect("client")

--- a/src/api.rs
+++ b/src/api.rs
@@ -609,6 +609,8 @@ pub struct AppInstall {
     pub installed_version: String,
     #[serde(default)]
     pub manifest: Option<serde_json::Value>,
+    #[serde(default)]
+    pub serving: String,
 }
 
 #[derive(Deserialize)]
@@ -1251,13 +1253,14 @@ mod tests {
         let _m = server.mock("GET", "/v1/apps/app-id/installs")
             .match_header("authorization", "Bearer AT")
             .with_status(200)
-            .with_body(r#"{"installs":[{"moduleId":"m1","slug":"core","installedVersion":"1.2.3","manifest":{"provides":[{"key":"x"}]}}]}"#)
+            .with_body(r#"{"installs":[{"moduleId":"m1","slug":"core","installedVersion":"1.2.3","serving":"tunnel","manifest":{"provides":[{"key":"x"}]}}]}"#)
             .create();
         let installs = list_app_installs(&test_client(), &server.url(), "AT", "app-id").unwrap();
         assert_eq!(
             installs[0].manifest.as_ref().unwrap()["provides"][0]["key"],
             "x"
         );
+        assert_eq!(installs[0].serving, "tunnel");
     }
 
     #[test]

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -139,6 +139,10 @@ pub(crate) fn platform_token_file(root: &Path, slug: &str) -> PathBuf {
         .join(format!("ms-platform-token-{slug}"))
 }
 
+fn capability_skip_file(root: &Path) -> PathBuf {
+    root.join(".secret").join("ms-skip-capability-check")
+}
+
 /// How often the supervisor polls module sources for changes — matches the
 /// shell runner's air `poll_interval = 2000`.
 const REBUILD_POLL: Duration = Duration::from_millis(2000);
@@ -271,6 +275,17 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
         None
     };
 
+    // Compose files in existing module workspaces predate this flag and do
+    // not forward arbitrary host env. A bind-mounted marker crosses the same
+    // host→runner boundary as platform tokens without rewriting user compose.
+    let skip_file = capability_skip_file(root);
+    if args.skip_capability_check {
+        std::fs::create_dir_all(root.join(".secret"))
+            .context("dev: create .secret directory for capability-check marker")?;
+        std::fs::write(&skip_file, b"1")
+            .context("dev: write capability-check marker for inner runner")?;
+    }
+
     // With --share on a live tunnel, spin up the host-side bundle watcher.
     // It's the only process holding the user access token (credentials.json,
     // never mounted into the runner) AND able to read each module's built
@@ -311,17 +326,8 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
     if let Some(secret) = &internal_secret {
         compose.env("MS_INTERNAL_SECRET", secret);
     }
-    // Outer mode delegates the actual runner to compose, so the escape hatch
-    // has to cross that process boundary as an env var. Compose only forwards
-    // what its own `environment:` block names (the same reason
-    // MS_INTERNAL_SECRET is declared there), so say so rather than leave the
-    // flag silently inert on a compose file that doesn't list it.
     if args.skip_capability_check {
         compose.env("MS_SKIP_CAPABILITY_CHECK", "1");
-        eprintln!(
-            "{} --skip-capability-check reaches the runner via MS_SKIP_CAPABILITY_CHECK; the compose file must forward it",
-            warn_prefix()
-        );
     }
 
     let compose_status = compose.status().map_err(|e| match e.kind() {
@@ -340,6 +346,9 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
     // Cleanup per-module token files.
     for f in &token_files {
         let _ = std::fs::remove_file(f);
+    }
+    if args.skip_capability_check {
+        let _ = std::fs::remove_file(skip_file);
     }
 
     if let Some((handles, runtime)) = tunnel_state {
@@ -487,8 +496,12 @@ fn run_inner(root: &Path, args: &DevArgs) -> Result<()> {
         // the module's own os.Getenv("MS_MODULE_ID") at runtime resolves.
         // The <SLUG> suffix is a root-.env bookkeeping detail; it never
         // reaches the child process.
-        let mut envs: Vec<(String, String)> =
-            module_process_envs(&db_url, port, module_id, &token_file);
+        let mut envs: Vec<(String, String)> = module_process_envs(
+            &db_url,
+            port,
+            module_id,
+            token_file.is_file().then_some(token_file.as_path()),
+        );
         // Pass through env vars from compose (MS_INTERNAL_SECRET is the
         // per-session secret minted by the outer run; the rest configure
         // infrastructure and the platform plane).
@@ -552,8 +565,8 @@ fn run_inner(root: &Path, args: &DevArgs) -> Result<()> {
     // A failed check falls straight through to the shared teardown below and
     // its error becomes this function's — dev must not keep serving a
     // workspace whose contributions cannot land.
-    let contribution_result = check_contributions(root, &check_routes, args);
-    if contribution_result.is_ok() {
+    let contribution_result = check_contributions(root, &check_routes, args, &rx);
+    if matches!(contribution_result, Ok(CheckOutcome::Complete)) {
         // Wait for Ctrl-C, or for every supervisor to finish (a supervisor
         // only returns on its own in one-shot mode, after its module exits).
         loop {
@@ -582,7 +595,7 @@ fn run_inner(root: &Path, args: &DevArgs) -> Result<()> {
     // final batch before the process exits.
     thread::sleep(Duration::from_millis(300));
 
-    contribution_result
+    contribution_result.map(|_| ())
 }
 
 fn capability_check_skipped(flag: bool, env: Option<&str>) -> bool {
@@ -603,13 +616,39 @@ const CONTRIBUTION_CHECK_BUDGET: Duration = Duration::from_secs(20);
 /// slot its resolvable host does not declare. Until this existed the failure
 /// mode was silence: the host's reader returns an empty list for "typo'd slot"
 /// exactly as it does for "not installed".
-fn check_contributions(root: &Path, routes: &HashMap<String, u16>, args: &DevArgs) -> Result<()> {
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CheckOutcome {
+    Complete,
+    Interrupted,
+}
+
+fn check_contributions(
+    root: &Path,
+    routes: &HashMap<String, u16>,
+    args: &DevArgs,
+    rx: &mpsc::Receiver<()>,
+) -> Result<CheckOutcome> {
     use crate::commands::module::capabilities::index::{self, Resolved, Tier};
     use crate::commands::module::capabilities::{resolve, wire::Manifest};
 
     let skip_env = std::env::var("MS_SKIP_CAPABILITY_CHECK").ok();
-    if capability_check_skipped(args.skip_capability_check, skip_env.as_deref()) {
-        return Ok(());
+    if capability_check_skipped(args.skip_capability_check, skip_env.as_deref())
+        || capability_skip_file(root).is_file()
+    {
+        return Ok(CheckOutcome::Complete);
+    }
+    // A token file is written only by outer tunnel setup. Without one the
+    // SDK cannot authenticate this internal route, so polling merely spends
+    // the entire boot budget on a state that cannot become ready.
+    if !routes
+        .keys()
+        .any(|slug| platform_token_file(root, slug).is_file())
+    {
+        eprintln!(
+            "{} contribution check skipped (no dev tunnel platform token)",
+            warn_prefix()
+        );
+        return Ok(CheckOutcome::Complete);
     }
     let client = http::client(Duration::from_secs(2))?;
     let deadline = Instant::now() + CONTRIBUTION_CHECK_BUDGET;
@@ -617,6 +656,12 @@ fn check_contributions(root: &Path, routes: &HashMap<String, u16>, args: &DevArg
     let mut resolved = Vec::new();
     let mut last_reason: HashMap<String, String> = HashMap::new();
     while !pending.is_empty() && Instant::now() < deadline {
+        match rx.try_recv() {
+            Ok(()) | Err(mpsc::TryRecvError::Disconnected) => {
+                return Ok(CheckOutcome::Interrupted);
+            }
+            Err(mpsc::TryRecvError::Empty) => {}
+        }
         let probes: Vec<_> = pending
             .iter()
             .map(|(slug, port)| (slug.clone(), *port))
@@ -660,7 +705,12 @@ fn check_contributions(root: &Path, routes: &HashMap<String, u16>, args: &DevArg
             }
         }
         if !pending.is_empty() {
-            thread::sleep(Duration::from_millis(500));
+            match rx.recv_timeout(Duration::from_millis(500)) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    return Ok(CheckOutcome::Interrupted);
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+            }
         }
     }
 
@@ -677,7 +727,7 @@ fn check_contributions(root: &Path, routes: &HashMap<String, u16>, args: &DevArg
         );
     }
     if resolved.is_empty() {
-        return Ok(());
+        return Ok(CheckOutcome::Complete);
     }
 
     let report = index::classify(&resolved);
@@ -690,11 +740,23 @@ fn check_contributions(root: &Path, routes: &HashMap<String, u16>, args: &DevArg
     {
         eprintln!("{} {}", warn_prefix(), diagnostic.detail);
     }
+    for diagnostic in report
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == "payload_mismatch")
+    {
+        eprintln!(
+            "{} {} {}",
+            warn_prefix(),
+            style(&diagnostic.module).cyan().bold(),
+            diagnostic.detail
+        );
+    }
 
     let failures: Vec<_> = report
         .diagnostics
         .iter()
-        .filter(|d| matches!(d.code, "slot_unknown" | "payload_mismatch"))
+        .filter(|d| d.severity == index::Severity::Error && d.code == "slot_unknown")
         .collect();
     if !failures.is_empty() {
         eprintln!();
@@ -743,7 +805,7 @@ fn check_contributions(root: &Path, routes: &HashMap<String, u16>, args: &DevArg
             style("unfilled").dim()
         );
     }
-    Ok(())
+    Ok(CheckOutcome::Complete)
 }
 
 /// Own one module's build → run → watch → restart loop.
@@ -836,17 +898,20 @@ fn module_process_envs(
     db_url: &str,
     port: u16,
     module_id: &str,
-    token_file: &Path,
+    token_file: Option<&Path>,
 ) -> Vec<(String, String)> {
-    vec![
+    let mut envs = vec![
         ("MS_LOCAL_DB_URL".into(), db_url.to_string()),
         ("PORT".into(), port.to_string()),
         ("MS_MODULE_ID".into(), module_id.to_string()),
-        (
+    ];
+    if let Some(token_file) = token_file {
+        envs.push((
             "MS_PLATFORM_TOKEN_FILE".into(),
             token_file.display().to_string(),
-        ),
-    ]
+        ));
+    }
+    envs
 }
 
 fn append_passthrough_env(envs: &mut Vec<(String, String)>) {
@@ -1242,7 +1307,7 @@ mod tests {
             "postgres://x/y",
             18080,
             "mbb8a3f8b123456789abcdef012345678",
-            Path::new("/tmp/.ms-platform-token-media"),
+            Some(Path::new("/tmp/.ms-platform-token-media")),
         );
         assert!(envs.contains(&(
             "MS_MODULE_ID".to_string(),
@@ -1265,7 +1330,7 @@ mod tests {
             "postgres://x/y",
             18080,
             "moauthcoreid",
-            Path::new("/tmp/.ms-platform-token-oauth-core"),
+            Some(Path::new("/tmp/.ms-platform-token-oauth-core")),
         );
         assert!(
             envs.iter().any(|(k, _)| k == "MS_MODULE_ID"),
@@ -1274,6 +1339,15 @@ mod tests {
         assert!(
             !envs.iter().any(|(k, _)| k.starts_with("MS_MODULE_ID_")),
             "child env must not carry a suffixed MS_MODULE_ID_* key: {envs:?}"
+        );
+    }
+
+    #[test]
+    fn module_process_envs_does_not_configure_auth_without_a_token() {
+        let envs = module_process_envs("postgres://x/y", 18080, "module-id", None);
+        assert!(
+            !envs.iter().any(|(key, _)| key == "MS_PLATFORM_TOKEN_FILE"),
+            "an absent token must not put the SDK into fail-closed configured mode"
         );
     }
 

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -58,7 +58,7 @@ mod proxy;
 mod reload;
 mod share;
 mod tunnel;
-mod workspace;
+pub(crate) mod workspace;
 
 const PASSTHROUGH_ENV: [&str; 10] = [
     "MS_INTERNAL_SECRET",
@@ -108,30 +108,33 @@ pub struct DevArgs {
         action = clap::ArgAction::Set
     )]
     watch: bool,
+    /// Skip the co-located contribution/slot cross-check at boot. Also honored via MS_SKIP_CAPABILITY_CHECK=1.
+    #[arg(long)]
+    skip_capability_check: bool,
 }
 
 const DEFAULT_LOCAL_URL: &str = "http://localhost";
-const DEFAULT_MODULE_PORT: u16 = 9080;
+pub(crate) const DEFAULT_MODULE_PORT: u16 = 9080;
 
 // Inner-runner port layout, matching the retired dev-runner.sh: modules
 // bind sequentially from 18080 in go.work order, esbuild livereload
 // servers from 8089 (per web-enabled module), and the dev-proxy
 // multiplexes them on 8080 (host-published as 9080/9089).
-const INTERNAL_PORT_BASE: u16 = 18080;
+pub(crate) const INTERNAL_PORT_BASE: u16 = 18080;
 const LR_PORT_BASE: u16 = 8089;
-const PROXY_PORT_DEFAULT: u16 = 8080;
+pub(crate) const PROXY_PORT_DEFAULT: u16 = 8080;
 
 /// Route prefix multiplexing modules on one port. The proxy parses it off
 /// incoming targets and tunnel registration embeds it in each module's
 /// local_url — dispatch forwards to exactly what was registered, so the
 /// two must agree.
-const MODULE_ROUTE_PREFIX: &str = "/_m/";
+pub(crate) const MODULE_ROUTE_PREFIX: &str = "/_m/";
 
 /// Per-module platform-token file. The name is a host↔container contract:
 /// the outer run writes it into `.secret/` next to go.work, and the inner
 /// runner points each module's MS_PLATFORM_TOKEN_FILE at it through the
 /// `.:/modules` bind mount.
-fn platform_token_file(root: &Path, slug: &str) -> PathBuf {
+pub(crate) fn platform_token_file(root: &Path, slug: &str) -> PathBuf {
     root.join(".secret")
         .join(format!("ms-platform-token-{slug}"))
 }
@@ -307,6 +310,18 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
     // module process as the SDK's legacy InternalAuth fallback.
     if let Some(secret) = &internal_secret {
         compose.env("MS_INTERNAL_SECRET", secret);
+    }
+    // Outer mode delegates the actual runner to compose, so the escape hatch
+    // has to cross that process boundary as an env var. Compose only forwards
+    // what its own `environment:` block names (the same reason
+    // MS_INTERNAL_SECRET is declared there), so say so rather than leave the
+    // flag silently inert on a compose file that doesn't list it.
+    if args.skip_capability_check {
+        compose.env("MS_SKIP_CAPABILITY_CHECK", "1");
+        eprintln!(
+            "{} --skip-capability-check reaches the runner via MS_SKIP_CAPABILITY_CHECK; the compose file must forward it",
+            warn_prefix()
+        );
     }
 
     let compose_status = compose.status().map_err(|e| match e.kind() {
@@ -516,6 +531,7 @@ fn run_inner(root: &Path, args: &DevArgs) -> Result<()> {
         .and_then(|v| v.parse().ok())
         .unwrap_or(PROXY_PORT_DEFAULT);
     let route_count = routes.len();
+    let check_routes = routes.clone();
     let proxy_port = proxy::spawn(proxy_port, routes)?;
     eprintln!(
         "{} dev-proxy listening on :{} ({} routes)",
@@ -524,21 +540,30 @@ fn run_inner(root: &Path, args: &DevArgs) -> Result<()> {
         route_count
     );
 
-    // Wait for Ctrl-C, or for every supervisor to finish (a supervisor
-    // only returns on its own in one-shot mode, after its module exits).
+    // Installed BEFORE the contribution check so a Ctrl-C during its readiness
+    // wait is buffered on the channel and breaks the loop immediately below,
+    // instead of killing the process with the module children still running.
     let (tx, rx) = mpsc::channel::<()>();
     ctrlc::set_handler(move || {
         let _ = tx.send(());
     })
     .context("dev: install ctrl-c handler")?;
 
-    loop {
-        if supervisors.iter().all(|h| h.is_finished()) {
-            break;
-        }
-        match rx.recv_timeout(SUPERVISE_TICK) {
-            Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
-            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+    // A failed check falls straight through to the shared teardown below and
+    // its error becomes this function's — dev must not keep serving a
+    // workspace whose contributions cannot land.
+    let contribution_result = check_contributions(root, &check_routes, args);
+    if contribution_result.is_ok() {
+        // Wait for Ctrl-C, or for every supervisor to finish (a supervisor
+        // only returns on its own in one-shot mode, after its module exits).
+        loop {
+            if supervisors.iter().all(|h| h.is_finished()) {
+                break;
+            }
+            match rx.recv_timeout(SUPERVISE_TICK) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            }
         }
     }
 
@@ -557,6 +582,167 @@ fn run_inner(root: &Path, args: &DevArgs) -> Result<()> {
     // final batch before the process exits.
     thread::sleep(Duration::from_millis(300));
 
+    contribution_result
+}
+
+fn capability_check_skipped(flag: bool, env: Option<&str>) -> bool {
+    flag || env.is_some_and(|value| {
+        let value = value.trim();
+        !value.is_empty() && value != "0" && !value.eq_ignore_ascii_case("false")
+    })
+}
+
+/// How long boot waits for every module to serve its manifest. Generous enough
+/// to cover the first cold `go build` of a workspace, short enough that a
+/// module that will never answer (auth failing closed, a crash loop) does not
+/// stall dev indefinitely.
+const CONTRIBUTION_CHECK_BUDGET: Duration = Duration::from_secs(20);
+
+/// Cross-check every co-located module's declared `ContributesTo` against the
+/// hosts' declared `Provide` slots, and fail boot when a contribution targets a
+/// slot its resolvable host does not declare. Until this existed the failure
+/// mode was silence: the host's reader returns an empty list for "typo'd slot"
+/// exactly as it does for "not installed".
+fn check_contributions(root: &Path, routes: &HashMap<String, u16>, args: &DevArgs) -> Result<()> {
+    use crate::commands::module::capabilities::index::{self, Resolved, Tier};
+    use crate::commands::module::capabilities::{resolve, wire::Manifest};
+
+    let skip_env = std::env::var("MS_SKIP_CAPABILITY_CHECK").ok();
+    if capability_check_skipped(args.skip_capability_check, skip_env.as_deref()) {
+        return Ok(());
+    }
+    let client = http::client(Duration::from_secs(2))?;
+    let deadline = Instant::now() + CONTRIBUTION_CHECK_BUDGET;
+    let mut pending = routes.clone();
+    let mut resolved = Vec::new();
+    let mut last_reason: HashMap<String, String> = HashMap::new();
+    while !pending.is_empty() && Instant::now() < deadline {
+        let probes: Vec<_> = pending
+            .iter()
+            .map(|(slug, port)| (slug.clone(), *port))
+            .collect();
+        for (slug, port) in probes {
+            let url = format!("http://127.0.0.1:{port}{}", resolve::MANIFEST_PATH);
+            let Ok(response) = resolve::request_headers(client.get(url), root, &slug).send() else {
+                continue;
+            };
+            if !response.status().is_success() {
+                // 503 here is the SDK failing closed on an unreadable
+                // MS_PLATFORM_TOKEN_FILE — a plain (non-tunnel) `dev` leaves
+                // modules in exactly that state, so record it for the warning.
+                last_reason.insert(
+                    slug,
+                    format!("HTTP {} on :{port}", response.status().as_u16()),
+                );
+                continue;
+            }
+            match response.json::<Manifest>() {
+                Ok(manifest) => {
+                    let keys: Vec<_> = manifest.versions.keys().cloned().collect();
+                    let version =
+                        module_meta::latest_version(&keys).unwrap_or_else(|| "unknown".into());
+                    resolved.push(Resolved {
+                        slug: if manifest.slug.is_empty() {
+                            slug.clone()
+                        } else {
+                            manifest.slug.clone()
+                        },
+                        id: manifest.id.clone(),
+                        version: version.trim_start_matches('v').into(),
+                        tier: Tier::L,
+                        manifest,
+                    });
+                    pending.remove(&slug);
+                }
+                Err(error) => {
+                    last_reason.insert(slug, format!("manifest did not parse: {error}"));
+                }
+            }
+        }
+        if !pending.is_empty() {
+            thread::sleep(Duration::from_millis(500));
+        }
+    }
+
+    // An unreachable module is never fatal: it may still be compiling, and a
+    // capability check must not be the thing that stops a dev session.
+    for slug in pending.keys() {
+        let reason = last_reason
+            .get(slug)
+            .cloned()
+            .unwrap_or_else(|| "no response".into());
+        eprintln!(
+            "{} contribution check skipped {slug} ({reason})",
+            warn_prefix()
+        );
+    }
+    if resolved.is_empty() {
+        return Ok(());
+    }
+
+    let report = index::classify(&resolved);
+    // A contribution into a host outside this workspace is legal in dev — the
+    // install-time gate is what checks those.
+    for diagnostic in report
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == "host_unresolvable")
+    {
+        eprintln!("{} {}", warn_prefix(), diagnostic.detail);
+    }
+
+    let failures: Vec<_> = report
+        .diagnostics
+        .iter()
+        .filter(|d| matches!(d.code, "slot_unknown" | "payload_mismatch"))
+        .collect();
+    if !failures.is_empty() {
+        eprintln!();
+        for diagnostic in &failures {
+            eprintln!(
+                "{} {} {}",
+                style("error:").red().bold(),
+                style(&diagnostic.module).cyan().bold(),
+                diagnostic.detail
+            );
+        }
+        eprintln!(
+            "  {}",
+            style(
+                "fix the slot name (or declare it on the host with ms.Provide); \
+                 pass --skip-capability-check to boot anyway"
+            )
+            .dim()
+        );
+        eprintln!();
+        return Err(anyhow!(
+            "contribution check failed: {} contribution(s) target a slot their host does not declare",
+            failures.len()
+        ));
+    }
+
+    let unfilled: Vec<_> = report
+        .slots
+        .iter()
+        .filter(|slot| slot.filled_by.is_empty())
+        .collect();
+    eprintln!(
+        "{} contributions checked — {} of {} host slots filled",
+        ok_mark(),
+        report.slots.len() - unfilled.len(),
+        report.slots.len()
+    );
+    // The coverage report: unfilled slots are legal, but they had been
+    // invisible, so name them.
+    for slot in unfilled {
+        eprintln!(
+            "  {} {}/{} {}",
+            style("○").yellow(),
+            slot.host,
+            slot.key,
+            style("unfilled").dim()
+        );
+    }
     Ok(())
 }
 
@@ -1037,6 +1223,18 @@ fn mint_internal_secret() -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn capability_skip_flag_parsing() {
+        assert!(capability_check_skipped(true, None));
+        assert!(capability_check_skipped(false, Some("1")));
+        assert!(capability_check_skipped(false, Some("yes")));
+        assert!(!capability_check_skipped(false, None));
+        assert!(!capability_check_skipped(false, Some("")));
+        assert!(!capability_check_skipped(false, Some("0")));
+        assert!(!capability_check_skipped(false, Some("false")));
+        assert!(!capability_check_skipped(false, Some("FALSE")));
+    }
 
     #[test]
     fn module_process_envs_includes_ms_module_id() {

--- a/src/commands/dev/module_meta.rs
+++ b/src/commands/dev/module_meta.rs
@@ -213,6 +213,15 @@ pub(crate) struct SemVer {
     pre: Vec<PreId>,
 }
 
+/// Build a release SemVer from a core triple — bound construction for
+/// version-constraint matching (see commands::module::capabilities::version).
+pub(crate) fn semver_from_core(major: u64, minor: u64, patch: u64) -> SemVer {
+    SemVer {
+        core: (major, minor, patch),
+        pre: Vec::new(),
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum PreId {
     // Variant order is load-bearing: derived Ord gives Num < Alpha, which

--- a/src/commands/dev/workspace.rs
+++ b/src/commands/dev/workspace.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result, anyhow};
 
 /// A module entry discovered from `go.work`.
 #[derive(Debug, Clone)]
-pub(super) struct WorkspaceModule {
+pub(crate) struct WorkspaceModule {
     /// Relative directory from the go.work root (e.g. `./oauth-core` → `oauth-core`).
     pub dir: PathBuf,
     /// Absolute path to the module directory.
@@ -17,7 +17,7 @@ pub(super) struct WorkspaceModule {
 /// Parse `go.work` in `root` and return the list of `use` directives as
 /// module entries. Fails if `go.work` is missing or contains no `use`
 /// directives.
-pub(super) fn discover_modules(root: &Path) -> Result<Vec<WorkspaceModule>> {
+pub(crate) fn discover_modules(root: &Path) -> Result<Vec<WorkspaceModule>> {
     let go_work = root.join("go.work");
     let body =
         fs::read_to_string(&go_work).with_context(|| format!("dev: read {}", go_work.display()))?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -90,6 +90,8 @@ enum Command {
     /// Manage applications on the platform.
     #[command(visible_alias = "app")]
     Apps(app::AppArgs),
+    /// Manage developer modules and inspect their capability surface.
+    Module(module::ModuleArgs),
     /// Run modules locally with supporting services. Scans go.work for
     /// monorepo mode; falls back to single-module if only main.go exists.
     Dev(dev::DevArgs),
@@ -103,6 +105,7 @@ impl Cli {
             Command::Logout(args) => logout::run(args),
             Command::Whoami(args) => whoami::run(args),
             Command::Apps(args) => app::run(args),
+            Command::Module(args) => module::run(args),
             Command::Dev(args) => dev::run(args),
         }
     }

--- a/src/commands/module/capabilities/index.rs
+++ b/src/commands/module/capabilities/index.rs
@@ -112,6 +112,7 @@ pub(crate) struct Diagnostic {
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Severity {
     Error,
+    Warning,
     Info,
 }
 
@@ -241,8 +242,12 @@ pub(crate) fn classify(resolved: &[Resolved]) -> Report {
             if let (Some(schema), Some(payload)) = (&host_slot.payload, &contribution.payload)
                 && let Err(reason) = schema::validate(schema, payload)
             {
+                // Reflector-required fields are stricter than the host's
+                // Provide[T] decoder, which is the real registration boundary.
+                // Keep obvious payload drift visible without making offline
+                // inference reject a contribution the runtime accepts.
                 report.diagnostics.push(diagnostic(
-                    Severity::Error,
+                    Severity::Warning,
                     "payload_mismatch",
                     contributor,
                     format!(
@@ -399,21 +404,31 @@ mod tests {
         }
     }
 
-    /// Modeled on the real oauth-core: one slot carrying a payload schema, one
-    /// exposed table, one emitted event.
+    /// The payload schemas come from a captured SDK manifest so tests exercise
+    /// the `$ref`/`$defs` wire shape modules actually serve.
     fn oauth_core() -> Resolved {
+        let captured: Value = serde_json::from_str(include_str!(
+            "../../../../tests/fixtures/sdk-capabilities-manifest.json"
+        ))
+        .expect("captured SDK manifest");
+        let provides: Vec<_> = captured["provides"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|provide| {
+                matches!(
+                    provide["key"].as_str(),
+                    Some("auth-provider" | "user-detail-blocks")
+                )
+            })
+            .cloned()
+            .collect();
         module(
             "oauth-core",
             "0.1.0",
             json!({
                 "slug": "oauth-core",
-                "provides": [
-                    {"key": "auth-provider", "payload": {
-                        "type": "object", "required": ["slug"],
-                        "properties": {"slug": {"type": "string"}, "name": {"type": "string"}}
-                    }},
-                    {"key": "user-detail-blocks"}
-                ],
+                "provides": provides,
                 "exposes": {"tables": ["users"]},
                 "permissions": [{"name": "users.read"}],
                 "events": {"emits": ["user.created"]}
@@ -520,14 +535,56 @@ mod tests {
         let report = classify(&[
             oauth_core(),
             contributor(
-                "oauth-google",
+                "users-profile",
                 json!({"contributesTo": [
-                    {"host": "oauth-core", "slot": "auth-provider", "payload": {"slug": 7}}
+                    {"host": "oauth-core", "slot": "user-detail-blocks",
+                     "payload": {"totally": "wrong", "nope": [1, 2, 3]}}
                 ]}),
             ),
         ]);
         let detail = only(&report, "payload_mismatch");
-        assert!(detail.contains("expected string"), "{detail}");
+        assert!(detail.contains("required property is missing"), "{detail}");
+        assert_eq!(
+            report
+                .diagnostics
+                .iter()
+                .find(|d| d.code == "payload_mismatch")
+                .unwrap()
+                .severity,
+            Severity::Warning
+        );
+    }
+
+    #[test]
+    fn a_scalar_payload_against_a_real_object_schema_is_payload_mismatch() {
+        let captured: Value = serde_json::from_str(include_str!(
+            "../../../../tests/fixtures/sdk-capabilities-manifest.json"
+        ))
+        .unwrap();
+        let table_slot = captured["provides"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|provide| provide["key"] == "users-table-columns")
+            .unwrap()
+            .clone();
+        let host = module(
+            "oauth-core",
+            "0.1.0",
+            json!({"slug": "oauth-core", "provides": [table_slot]}),
+        );
+        let report = classify(&[
+            host,
+            contributor(
+                "users-profile",
+                json!({"contributesTo": [
+                    {"host": "oauth-core", "slot": "users-table-columns",
+                     "payload": "i am not even an object"}
+                ]}),
+            ),
+        ]);
+        let detail = only(&report, "payload_mismatch");
+        assert!(detail.contains("expected object"), "{detail}");
     }
 
     #[test]

--- a/src/commands/module/capabilities/index.rs
+++ b/src/commands/module/capabilities/index.rs
@@ -1,0 +1,654 @@
+use serde::Serialize;
+use serde_json::Value;
+
+use super::schema;
+use super::version;
+use super::wire::{Manifest, parse_ref};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub(crate) enum Tier {
+    #[serde(rename = "L")]
+    L,
+    #[serde(rename = "D")]
+    D,
+}
+
+impl std::fmt::Display for Tier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::L => "L",
+            Self::D => "D",
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Resolved {
+    pub slug: String,
+    pub id: String,
+    pub version: String,
+    pub tier: Tier,
+    pub manifest: Manifest,
+}
+
+impl Resolved {
+    fn name(&self) -> &str {
+        if self.slug.is_empty() {
+            &self.id
+        } else {
+            &self.slug
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Report {
+    pub resolved: Vec<ResolvedEntry>,
+    pub slots: Vec<SlotEntry>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ResolvedEntry {
+    pub module: String,
+    pub version: String,
+    pub tier: Tier,
+    pub provides: Vec<SlotSummary>,
+    pub exposes: ExposesOut,
+    pub permissions: Vec<String>,
+    pub events: EventsOut,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct SlotSummary {
+    pub key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ExposesOut {
+    pub tables: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct EventsOut {
+    pub emits: Vec<String>,
+    pub subscribes: std::collections::BTreeMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SlotEntry {
+    pub key: String,
+    pub host: String,
+    pub host_version: String,
+    pub tier: Tier,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<Value>,
+    pub filled_by: Vec<FilledBy>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct FilledBy {
+    pub module: String,
+    pub version: String,
+    pub tier: Tier,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Diagnostic {
+    pub severity: Severity,
+    pub code: &'static str,
+    pub module: String,
+    pub detail: String,
+    #[serde(skip)]
+    pub related_host: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Severity {
+    Error,
+    Info,
+}
+
+fn diagnostic(
+    severity: Severity,
+    code: &'static str,
+    module: &Resolved,
+    detail: String,
+    related_host: Option<String>,
+) -> Diagnostic {
+    Diagnostic {
+        severity,
+        code,
+        module: module.name().into(),
+        detail,
+        related_host,
+    }
+}
+
+fn find<'a>(resolved: &'a [Resolved], reference: &str) -> Option<&'a Resolved> {
+    resolved
+        .iter()
+        .find(|r| r.slug == reference || r.id == reference)
+}
+
+/// Cross-check every resolved module's declared surface against every other.
+pub(crate) fn classify(resolved: &[Resolved]) -> Report {
+    let mut report = Report {
+        resolved: Vec::new(),
+        slots: Vec::new(),
+        diagnostics: Vec::new(),
+    };
+    for module in resolved {
+        report.resolved.push(ResolvedEntry {
+            module: module.name().into(),
+            version: module.version.clone(),
+            tier: module.tier,
+            provides: module
+                .manifest
+                .provides
+                .iter()
+                .map(|s| SlotSummary {
+                    key: s.key.clone(),
+                    payload: s.payload.clone(),
+                })
+                .collect(),
+            exposes: ExposesOut {
+                tables: module.manifest.exposes.tables.clone(),
+            },
+            permissions: module
+                .manifest
+                .permissions
+                .iter()
+                .map(|p| p.name.clone())
+                .collect(),
+            events: EventsOut {
+                emits: module.manifest.events.emits.clone(),
+                subscribes: module.manifest.events.subscribes.clone(),
+            },
+        });
+        report
+            .slots
+            .extend(module.manifest.provides.iter().map(|slot| SlotEntry {
+                key: slot.key.clone(),
+                host: module.name().into(),
+                host_version: module.version.clone(),
+                tier: module.tier,
+                payload: slot.payload.clone(),
+                filled_by: Vec::new(),
+            }));
+    }
+    for contributor in resolved {
+        for contribution in &contributor.manifest.contributes_to {
+            let (host_slug, embedded) = parse_ref(&contribution.host);
+            let constraint = contribution.constraint.as_ref().or(embedded.as_ref());
+            let Some(host) = find(resolved, &host_slug) else {
+                report.diagnostics.push(diagnostic(Severity::Error, "host_unresolvable", contributor,
+                    format!("contributes to {}/{slot}; no resolvable module provides host \"{host_slug}\"", contribution.host, slot = contribution.slot),
+                    Some(host_slug)));
+                continue;
+            };
+            // Past this point the host has RESOLVED, so every message names the
+            // resolved module rather than echoing the raw `id@constraint` spec
+            // back — the slot reference has to read as `host/slot`.
+            let host_name = host.name();
+            if let Some(constraint) = constraint.filter(|c| !c.is_empty())
+                && !version::satisfies(constraint, &host.version)
+            {
+                report.diagnostics.push(diagnostic(Severity::Error, "version_skew", contributor,
+                    format!("contributes to {host_name}/{slot} pinned {constraint}, but the resolved host is {host_name}@{} (tier {})", host.version, host.tier, slot = contribution.slot),
+                    Some(host_name.into())));
+            }
+            let Some(host_slot) = host
+                .manifest
+                .provides
+                .iter()
+                .find(|s| s.key == contribution.slot)
+            else {
+                let mut declared: Vec<_> = host
+                    .manifest
+                    .provides
+                    .iter()
+                    .map(|s| s.key.as_str())
+                    .collect();
+                declared.sort_unstable();
+                let suffix = if declared.is_empty() {
+                    "declares no slots".into()
+                } else {
+                    format!("declares: {}", declared.join(", "))
+                };
+                report.diagnostics.push(diagnostic(Severity::Error, "slot_unknown", contributor,
+                    format!("contributes to {host_name}/{slot}; {host_name}@{} (tier {}) declares no such slot ({suffix})", host.version, host.tier, slot = contribution.slot),
+                    Some(host_name.into())));
+                continue;
+            };
+            if let Some(slot) = report
+                .slots
+                .iter_mut()
+                .find(|s| s.host == host_name && s.key == contribution.slot)
+            {
+                slot.filled_by.push(FilledBy {
+                    module: contributor.name().into(),
+                    version: contributor.version.clone(),
+                    tier: contributor.tier,
+                });
+            }
+            if let (Some(schema), Some(payload)) = (&host_slot.payload, &contribution.payload)
+                && let Err(reason) = schema::validate(schema, payload)
+            {
+                report.diagnostics.push(diagnostic(
+                    Severity::Error,
+                    "payload_mismatch",
+                    contributor,
+                    format!(
+                        "payload for {host_name}/{slot} does not match the host slot schema: {reason}",
+                        slot = contribution.slot
+                    ),
+                    Some(host_name.into()),
+                ));
+            }
+        }
+        for dependency in &contributor.manifest.dependencies {
+            let (dep_slug, embedded) = parse_ref(&dependency.id);
+            // A dependency not co-located is normal; only contributions require
+            // their host to resolve because they must join a declared slot.
+            let Some(dep) = find(resolved, &dep_slug) else {
+                continue;
+            };
+            let constraint = dependency
+                .version
+                .as_ref()
+                .filter(|v| !v.is_empty())
+                .or(embedded.as_ref());
+            if let Some(constraint) = constraint
+                && !version::satisfies(constraint, &dep.version)
+            {
+                report.diagnostics.push(diagnostic(
+                    Severity::Error,
+                    "version_skew",
+                    contributor,
+                    format!(
+                        "depends on {} {constraint}, but the resolved module is {}@{} (tier {})",
+                        dependency.id,
+                        dep.name(),
+                        dep.version,
+                        dep.tier
+                    ),
+                    Some(dep.name().into()),
+                ));
+            }
+            for table in dependency
+                .tables
+                .iter()
+                .filter(|t| !dep.manifest.exposes.tables.contains(t))
+            {
+                // This catches the live-403 class where local source expects an
+                // exposure absent from the version that actually resolved.
+                let exposed = list_or_none(&dep.manifest.exposes.tables, "tables");
+                report.diagnostics.push(diagnostic(
+                    Severity::Error,
+                    "version_skew",
+                    contributor,
+                    format!(
+                        "depends on {} table \"{table}\", but {}@{} (tier {}) exposes {exposed}",
+                        dep.name(),
+                        dep.name(),
+                        dep.version,
+                        dep.tier
+                    ),
+                    Some(dep.name().into()),
+                ));
+            }
+            for event in dependency
+                .events
+                .iter()
+                .filter(|e| !dep.manifest.events.emits.contains(e))
+            {
+                let emitted = list_or_none(&dep.manifest.events.emits, "events");
+                report.diagnostics.push(diagnostic(
+                    Severity::Error,
+                    "version_skew",
+                    contributor,
+                    format!(
+                        "depends on {} event \"{event}\", but {}@{} (tier {}) emits {emitted}",
+                        dep.name(),
+                        dep.name(),
+                        dep.version,
+                        dep.tier
+                    ),
+                    Some(dep.name().into()),
+                ));
+            }
+        }
+    }
+    for slot in report.slots.iter().filter(|s| s.filled_by.is_empty()) {
+        report.diagnostics.push(Diagnostic {
+            severity: Severity::Info,
+            code: "slot_unfilled",
+            module: slot.host.clone(),
+            detail: format!(
+                "slot {}/{} is declared but no resolvable module contributes to it",
+                slot.host, slot.key
+            ),
+            related_host: Some(slot.host.clone()),
+        });
+    }
+    sort_report(&mut report);
+    report
+}
+
+fn list_or_none(values: &[String], noun: &str) -> String {
+    if values.is_empty() {
+        format!("no {noun}")
+    } else {
+        values.join(", ")
+    }
+}
+
+pub(crate) fn sort_report(report: &mut Report) {
+    report.resolved.sort_by(|a, b| a.module.cmp(&b.module));
+    report
+        .slots
+        .sort_by(|a, b| (&a.host, &a.key).cmp(&(&b.host, &b.key)));
+    for slot in &mut report.slots {
+        slot.filled_by.sort_by(|a, b| a.module.cmp(&b.module));
+    }
+    report.diagnostics.sort_by(|a, b| {
+        (a.severity, a.code, &a.module, &a.detail).cmp(&(b.severity, b.code, &b.module, &b.detail))
+    });
+}
+
+/// Keep only the host, its contributors, slots, and related diagnostics.
+pub(crate) fn filter_host(mut report: Report, host: &str) -> Report {
+    let contributors: std::collections::BTreeSet<_> = report
+        .slots
+        .iter()
+        .filter(|s| s.host == host)
+        .flat_map(|s| s.filled_by.iter().map(|f| f.module.clone()))
+        .collect();
+    report
+        .resolved
+        .retain(|r| r.module == host || contributors.contains(&r.module));
+    report.slots.retain(|s| s.host == host);
+    report
+        .diagnostics
+        .retain(|d| d.module == host || d.related_host.as_deref() == Some(host));
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Fixtures are built by DESERIALIZING manifest JSON rather than by
+    /// constructing `Manifest` directly, so every test doubles as a wire-shape
+    /// test against what a module actually serves.
+    fn module(slug: &str, version: &str, manifest: Value) -> Resolved {
+        Resolved {
+            slug: slug.into(),
+            id: format!("m-{slug}"),
+            version: version.into(),
+            tier: Tier::L,
+            manifest: serde_json::from_value(manifest).expect("fixture manifest"),
+        }
+    }
+
+    /// Modeled on the real oauth-core: one slot carrying a payload schema, one
+    /// exposed table, one emitted event.
+    fn oauth_core() -> Resolved {
+        module(
+            "oauth-core",
+            "0.1.0",
+            json!({
+                "slug": "oauth-core",
+                "provides": [
+                    {"key": "auth-provider", "payload": {
+                        "type": "object", "required": ["slug"],
+                        "properties": {"slug": {"type": "string"}, "name": {"type": "string"}}
+                    }},
+                    {"key": "user-detail-blocks"}
+                ],
+                "exposes": {"tables": ["users"]},
+                "permissions": [{"name": "users.read"}],
+                "events": {"emits": ["user.created"]}
+            }),
+        )
+    }
+
+    fn contributor(slug: &str, manifest: Value) -> Resolved {
+        module(slug, "0.1.0", manifest)
+    }
+
+    fn codes(report: &Report) -> Vec<&str> {
+        report.diagnostics.iter().map(|d| d.code).collect()
+    }
+
+    fn only(report: &Report, code: &str) -> String {
+        let matching: Vec<_> = report
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == code)
+            .collect();
+        assert_eq!(
+            matching.len(),
+            1,
+            "expected one {code} in {:?}",
+            codes(report)
+        );
+        matching[0].detail.clone()
+    }
+
+    #[test]
+    fn a_contribution_to_a_known_slot_fills_it_and_raises_nothing() {
+        let report = classify(&[
+            oauth_core(),
+            contributor(
+                "oauth-google",
+                json!({"slug": "oauth-google", "contributesTo": [
+                    {"host": "oauth-core", "slot": "auth-provider", "payload": {"slug": "google"}}
+                ]}),
+            ),
+        ]);
+        let slot = report
+            .slots
+            .iter()
+            .find(|s| s.key == "auth-provider")
+            .expect("slot");
+        assert_eq!(slot.filled_by.len(), 1);
+        assert_eq!(slot.filled_by[0].module, "oauth-google");
+        assert_eq!(slot.filled_by[0].version, "0.1.0");
+        assert_eq!(slot.filled_by[0].tier, Tier::L);
+        // Only the second, genuinely unfilled slot is reported.
+        assert_eq!(codes(&report), ["slot_unfilled"]);
+    }
+
+    /// The `profile-store` bug, pinned: users-profile contributes into a slot
+    /// oauth-core does not declare, and nothing anywhere caught it.
+    #[test]
+    fn a_contribution_to_an_undeclared_slot_is_slot_unknown() {
+        let report = classify(&[
+            oauth_core(),
+            contributor(
+                "users-profile",
+                json!({"slug": "users-profile", "contributesTo": [
+                    {"host": "oauth-core", "slot": "profile-store",
+                     "payload": {"profileUrl": "/internal/profile"}}
+                ]}),
+            ),
+        ]);
+        let detail = only(&report, "slot_unknown");
+        assert!(detail.contains("oauth-core/profile-store"), "{detail}");
+        // The message must name what the host DOES declare, or the author still
+        // has to go grepping — the exact step that produced the bug.
+        assert!(
+            detail.contains("auth-provider, user-detail-blocks"),
+            "{detail}"
+        );
+        assert!(detail.contains("0.1.0"), "{detail}");
+    }
+
+    #[test]
+    fn a_declared_slot_with_no_contributor_is_info_only() {
+        let report = classify(&[oauth_core()]);
+        assert_eq!(codes(&report), ["slot_unfilled", "slot_unfilled"]);
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .all(|d| d.severity == Severity::Info)
+        );
+    }
+
+    #[test]
+    fn a_contribution_whose_host_resolves_nowhere_is_host_unresolvable() {
+        let report = classify(&[contributor(
+            "users-profile",
+            json!({"contributesTo": [{"host": "@mirrorstack/absent@^0.1", "slot": "x"}]}),
+        )]);
+        let detail = only(&report, "host_unresolvable");
+        assert!(detail.contains("\"absent\""), "{detail}");
+    }
+
+    #[test]
+    fn a_payload_failing_the_slot_schema_is_payload_mismatch() {
+        let report = classify(&[
+            oauth_core(),
+            contributor(
+                "oauth-google",
+                json!({"contributesTo": [
+                    {"host": "oauth-core", "slot": "auth-provider", "payload": {"slug": 7}}
+                ]}),
+            ),
+        ]);
+        let detail = only(&report, "payload_mismatch");
+        assert!(detail.contains("expected string"), "{detail}");
+    }
+
+    #[test]
+    fn a_constraint_excluding_the_resolved_host_version_is_version_skew() {
+        let report = classify(&[
+            oauth_core(),
+            contributor(
+                "oauth-google",
+                json!({"contributesTo": [
+                    {"host": "oauth-core", "slot": "auth-provider",
+                     "constraint": "^1", "payload": {"slug": "google"}}
+                ]}),
+            ),
+        ]);
+        let detail = only(&report, "version_skew");
+        assert!(detail.contains("^1"), "{detail}");
+        assert!(detail.contains("oauth-core@0.1.0"), "{detail}");
+    }
+
+    /// The live-403 class: local source declares a dependency read the resolved
+    /// version does not expose.
+    #[test]
+    fn a_dependency_on_an_unexposed_table_is_version_skew() {
+        let report = classify(&[
+            oauth_core(),
+            contributor(
+                "users-profile",
+                json!({"dependencies": [
+                    {"id": "@mirrorstack/oauth-core@^0.1", "tables": ["users", "sessions"]}
+                ]}),
+            ),
+        ]);
+        let detail = only(&report, "version_skew");
+        assert!(detail.contains("\"sessions\""), "{detail}");
+        assert!(detail.contains("exposes users"), "{detail}");
+    }
+
+    #[test]
+    fn a_dependency_on_a_module_outside_the_workspace_is_silent() {
+        // Depending on a module that simply is not co-located is normal; only
+        // contributions require their host to resolve.
+        let report = classify(&[contributor(
+            "users-profile",
+            json!({"dependencies": [{"id": "@mirrorstack/absent@^0.1", "tables": ["users"]}]}),
+        )]);
+        assert!(report.diagnostics.is_empty(), "{:?}", codes(&report));
+    }
+
+    /// The wire shape BEFORE the SDK adds `provides[].payload` and
+    /// `contributesTo[].constraint`. Their absence must never raise anything.
+    #[test]
+    fn the_pre_schema_wire_shape_raises_nothing() {
+        let report = classify(&[
+            module(
+                "oauth-core",
+                "0.1.0",
+                json!({"provides": [{"key": "auth-provider"}]}),
+            ),
+            contributor(
+                "oauth-google",
+                json!({"contributesTo": [{"host": "oauth-core", "slot": "auth-provider"}]}),
+            ),
+        ]);
+        assert!(report.diagnostics.is_empty(), "{:?}", codes(&report));
+    }
+
+    #[test]
+    fn output_order_is_deterministic() {
+        let report = classify(&[
+            module(
+                "z",
+                "0.1.0",
+                json!({"provides": [{"key": "b"}, {"key": "a"}]}),
+            ),
+            module("a", "0.1.0", json!({})),
+        ]);
+        assert_eq!(
+            report
+                .resolved
+                .iter()
+                .map(|e| e.module.as_str())
+                .collect::<Vec<_>>(),
+            ["a", "z"]
+        );
+        assert_eq!(
+            report
+                .slots
+                .iter()
+                .map(|s| s.key.as_str())
+                .collect::<Vec<_>>(),
+            ["a", "b"]
+        );
+    }
+
+    #[test]
+    fn filter_host_keeps_the_host_its_contributors_and_its_diagnostics() {
+        let report = classify(&[
+            oauth_core(),
+            contributor(
+                "oauth-google",
+                json!({"contributesTo": [
+                    {"host": "oauth-core", "slot": "auth-provider", "payload": {"slug": "google"}}
+                ]}),
+            ),
+            contributor("unrelated", json!({"provides": [{"key": "elsewhere"}]})),
+        ]);
+        let filtered = filter_host(report, "oauth-core");
+        assert_eq!(
+            filtered
+                .resolved
+                .iter()
+                .map(|r| r.module.as_str())
+                .collect::<Vec<_>>(),
+            ["oauth-core", "oauth-google"]
+        );
+        assert!(filtered.slots.iter().all(|s| s.host == "oauth-core"));
+        assert!(
+            filtered
+                .diagnostics
+                .iter()
+                .all(|d| d.module == "oauth-core")
+        );
+    }
+}

--- a/src/commands/module/capabilities/index.rs
+++ b/src/commands/module/capabilities/index.rs
@@ -140,24 +140,39 @@ fn find<'a>(resolved: &'a [Resolved], reference: &str) -> Option<&'a Resolved> {
 
 /// Cross-check every resolved module's declared surface against every other.
 pub(crate) fn classify(resolved: &[Resolved]) -> Report {
-    let validators: std::collections::HashMap<_, _> = resolved
-        .iter()
-        .flat_map(|module| {
-            module.manifest.provides.iter().filter_map(|slot| {
-                slot.payload.as_ref().map(|payload| {
-                    (
-                        (module.id.clone(), slot.key.clone()),
-                        schema::Validator::compile(payload),
-                    )
-                })
-            })
-        })
-        .collect();
     let mut report = Report {
         resolved: Vec::new(),
         slots: Vec::new(),
         diagnostics: Vec::new(),
     };
+    let validators: Vec<Vec<_>> = resolved
+        .iter()
+        .map(|module| {
+            module
+                .manifest
+                .provides
+                .iter()
+                .map(|slot| {
+                    slot.payload.as_ref().map(|payload| {
+                        schema::Validator::compile(payload).map_err(|reason| {
+                            report.diagnostics.push(diagnostic(
+                                Severity::Error,
+                                "schema_invalid",
+                                module,
+                                format!(
+                                    "schema for slot {}/{} could not be compiled: {reason}",
+                                    module.name(),
+                                    slot.key
+                                ),
+                                Some(module.name().into()),
+                            ));
+                            reason
+                        })
+                    })
+                })
+                .collect()
+        })
+        .collect();
     for module in resolved {
         report.resolved.push(ResolvedEntry {
             module: module.name().into(),
@@ -201,7 +216,11 @@ pub(crate) fn classify(resolved: &[Resolved]) -> Report {
         for contribution in &contributor.manifest.contributes_to {
             let (host_slug, embedded) = parse_ref(&contribution.host);
             let constraint = contribution.constraint.as_ref().or(embedded.as_ref());
-            let Some(host) = find(resolved, &host_slug) else {
+            let Some((host_idx, host)) = resolved
+                .iter()
+                .enumerate()
+                .find(|(_, r)| r.slug == host_slug || r.id == host_slug)
+            else {
                 report.diagnostics.push(diagnostic(Severity::Error, "host_unresolvable", contributor,
                     format!("contributes to {}/{slot}; no resolvable module provides host \"{host_slug}\"", contribution.host, slot = contribution.slot),
                     Some(host_slug)));
@@ -218,11 +237,12 @@ pub(crate) fn classify(resolved: &[Resolved]) -> Report {
                     format!("contributes to {host_name}/{slot} pinned {constraint}, but the resolved host is {host_name}@{} (tier {})", host.version, host.tier, slot = contribution.slot),
                     Some(host_name.into())));
             }
-            let Some(host_slot) = host
+            let Some((slot_idx, _)) = host
                 .manifest
                 .provides
                 .iter()
-                .find(|s| s.key == contribution.slot)
+                .enumerate()
+                .find(|(_, s)| s.key == contribution.slot)
             else {
                 let mut declared: Vec<_> = host
                     .manifest
@@ -253,11 +273,8 @@ pub(crate) fn classify(resolved: &[Resolved]) -> Report {
                 });
             }
             if let Some(payload) = &contribution.payload
-                && let Some(validator) = validators.get(&(host.id.clone(), host_slot.key.clone()))
-                && let Err(reason) = match validator {
-                    Ok(validator) => validator.validate(payload),
-                    Err(reason) => Err(reason.clone()),
-                }
+                && let Some(Ok(validator)) = &validators[host_idx][slot_idx]
+                && let Err(reason) = validator.validate(payload)
             {
                 // Reflector-required fields are stricter than the host's
                 // Provide[T] decoder, which is the real registration boundary.
@@ -602,6 +619,59 @@ mod tests {
         ]);
         let detail = only(&report, "payload_mismatch");
         assert!(detail.contains("object"), "{detail}");
+    }
+
+    #[test]
+    fn duplicate_slot_keys_validate_against_the_selected_first_slot() {
+        let report = classify(&[
+            module(
+                "host",
+                "0.1.0",
+                json!({"provides": [
+                    {"key": "duplicate", "payload": {"type": "string"}},
+                    {"key": "duplicate", "payload": {"type": "number"}}
+                ]}),
+            ),
+            contributor(
+                "contributor",
+                json!({"contributesTo": [
+                    {"host": "host", "slot": "duplicate", "payload": "valid for first"}
+                ]}),
+            ),
+        ]);
+
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != "payload_mismatch"),
+            "{:?}",
+            codes(&report)
+        );
+    }
+
+    #[test]
+    fn an_invalid_schema_is_reported_even_when_the_slot_is_unfilled() {
+        let report = classify(&[module(
+            "host",
+            "0.1.0",
+            json!({"provides": [
+                {"key": "broken", "payload": {"type": "not-a-json-schema-type"}}
+            ]}),
+        )]);
+
+        let detail = only(&report, "schema_invalid");
+        assert!(detail.contains("host/broken"), "{detail}");
+        assert_eq!(
+            report
+                .diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.code == "schema_invalid")
+                .unwrap()
+                .severity,
+            Severity::Error
+        );
+        assert!(codes(&report).contains(&"slot_unfilled"));
     }
 
     #[test]

--- a/src/commands/module/capabilities/index.rs
+++ b/src/commands/module/capabilities/index.rs
@@ -140,6 +140,19 @@ fn find<'a>(resolved: &'a [Resolved], reference: &str) -> Option<&'a Resolved> {
 
 /// Cross-check every resolved module's declared surface against every other.
 pub(crate) fn classify(resolved: &[Resolved]) -> Report {
+    let validators: std::collections::HashMap<_, _> = resolved
+        .iter()
+        .flat_map(|module| {
+            module.manifest.provides.iter().filter_map(|slot| {
+                slot.payload.as_ref().map(|payload| {
+                    (
+                        (module.id.clone(), slot.key.clone()),
+                        schema::Validator::compile(payload),
+                    )
+                })
+            })
+        })
+        .collect();
     let mut report = Report {
         resolved: Vec::new(),
         slots: Vec::new(),
@@ -239,8 +252,12 @@ pub(crate) fn classify(resolved: &[Resolved]) -> Report {
                     tier: contributor.tier,
                 });
             }
-            if let (Some(schema), Some(payload)) = (&host_slot.payload, &contribution.payload)
-                && let Err(reason) = schema::validate(schema, payload)
+            if let Some(payload) = &contribution.payload
+                && let Some(validator) = validators.get(&(host.id.clone(), host_slot.key.clone()))
+                && let Err(reason) = match validator {
+                    Ok(validator) => validator.validate(payload),
+                    Err(reason) => Err(reason.clone()),
+                }
             {
                 // Reflector-required fields are stricter than the host's
                 // Provide[T] decoder, which is the real registration boundary.
@@ -543,7 +560,7 @@ mod tests {
             ),
         ]);
         let detail = only(&report, "payload_mismatch");
-        assert!(detail.contains("required property is missing"), "{detail}");
+        assert!(detail.contains("required"), "{detail}");
         assert_eq!(
             report
                 .diagnostics
@@ -584,7 +601,7 @@ mod tests {
             ),
         ]);
         let detail = only(&report, "payload_mismatch");
-        assert!(detail.contains("expected object"), "{detail}");
+        assert!(detail.contains("object"), "{detail}");
     }
 
     #[test]

--- a/src/commands/module/capabilities/mod.rs
+++ b/src/commands/module/capabilities/mod.rs
@@ -1,0 +1,182 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow};
+use clap::Args;
+use console::style;
+
+use crate::commands::{ok_mark, warn_prefix};
+
+pub(crate) mod index;
+pub(crate) mod resolve;
+mod schema;
+mod version;
+pub(crate) mod wire;
+
+use index::{Report, Severity};
+
+#[derive(Args)]
+pub struct CapabilitiesArgs {
+    /// Workspace directory containing go.work. Defaults to the nearest go.work at or above the cwd.
+    #[arg(long)]
+    dir: Option<PathBuf>,
+    /// Resolve against module versions installed in this app (id or slug).
+    #[arg(long)]
+    app: Option<String>,
+    /// Only report this host module's slots and contributors.
+    #[arg(long)]
+    host: Option<String>,
+    /// Machine-readable output on stdout.
+    #[arg(long)]
+    json: bool,
+}
+
+fn workspace_root(dir: Option<&Path>) -> Result<PathBuf> {
+    let start = dir
+        .map(Path::to_path_buf)
+        .unwrap_or(std::env::current_dir()?);
+    start
+        .ancestors()
+        .find(|p| p.join("go.work").exists())
+        .map(Path::to_path_buf)
+        .ok_or_else(|| anyhow!("no go.work found at or above {}", start.display()))
+}
+
+pub(crate) fn run(args: CapabilitiesArgs) -> Result<()> {
+    // Tier P marketplace resolution is deliberately out of scope: this command
+    // reports only live co-location or versions actually installed in an app.
+    let (resolved, unreachable, source) = if let Some(app) = &args.app {
+        let (r, u) = resolve::tier_app(app)?;
+        (r, u, format!("tier D · versions installed in {app}"))
+    } else {
+        let root = workspace_root(args.dir.as_deref())?;
+        let (r, u) = resolve::tier_local(&root)?;
+        if r.is_empty() {
+            // Tier L reads LIVE manifests, the same source the runtime
+            // authorizes against — validating against local Go source instead
+            // would be theatre. So with nothing running there is no answer.
+            for module in &u {
+                eprintln!("{} {}: {}", warn_prefix(), module.slug, module.reason);
+            }
+            return Err(anyhow!(
+                "no module manifest could be read — run `mirrorstack dev --tunnel` in this workspace so co-located modules serve their manifests"
+            ));
+        }
+        (
+            r,
+            u,
+            format!("tier L · co-located go.work modules at {}", root.display()),
+        )
+    };
+    let mut report = index::classify(&resolved);
+    report
+        .diagnostics
+        .extend(resolve::unreachable_diagnostics(&unreachable));
+    index::sort_report(&mut report);
+    if let Some(host) = &args.host {
+        report = index::filter_host(report, host);
+    }
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_human(&source, &report);
+    }
+    let errors = report
+        .diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .count();
+    if errors > 0 {
+        return Err(anyhow!(
+            "{errors} capability error(s) — see the diagnostics above"
+        ));
+    }
+    Ok(())
+}
+
+/// Every line is tagged with the tier and version it came from — the module
+/// header carries them for its own declarations, and each slot line repeats
+/// them because slots from different hosts (and tiers) interleave. An
+/// untagged capability answer is a bug.
+fn print_human(source: &str, report: &Report) {
+    eprintln!("{} {}", ok_mark(), style(source).bold());
+    for module in &report.resolved {
+        eprintln!(
+            "\n  {}@{} {}",
+            style(&module.module).cyan().bold(),
+            module.version,
+            style(format!("[tier {}]", module.tier)).dim()
+        );
+        let keys: Vec<_> = module.provides.iter().map(|s| s.key.as_str()).collect();
+        for (label, values) in [
+            ("provides", keys.join(", ")),
+            ("exposes", module.exposes.tables.join(", ")),
+            ("permissions", module.permissions.join(", ")),
+            ("emits", module.events.emits.join(", ")),
+        ] {
+            if !values.is_empty() {
+                eprintln!("    {:<12}{values}", style(label).dim());
+            }
+        }
+    }
+
+    eprintln!("\n{}", style("Slots").bold());
+    for slot in &report.slots {
+        let where_from = style(format!("[{} tier {}]", slot.host_version, slot.tier)).dim();
+        if slot.filled_by.is_empty() {
+            eprintln!(
+                "  {} {}/{} {where_from} {}",
+                style("○").yellow(),
+                slot.host,
+                style(&slot.key).yellow(),
+                style("unfilled").yellow()
+            );
+        } else {
+            let filled = slot
+                .filled_by
+                .iter()
+                .map(|f| format!("{}@{} [tier {}]", f.module, f.version, f.tier))
+                .collect::<Vec<_>>()
+                .join(", ");
+            eprintln!(
+                "  {} {}/{} {where_from} filled by {filled}",
+                ok_mark(),
+                slot.host,
+                slot.key
+            );
+        }
+    }
+
+    if !report.diagnostics.is_empty() {
+        eprintln!("\n{}", style("Diagnostics").bold());
+        for d in &report.diagnostics {
+            let prefix = match d.severity {
+                Severity::Error => style("error:").red().bold(),
+                Severity::Info => style("info: ").dim().bold(),
+            };
+            eprintln!(
+                "  {prefix} {} {} {}",
+                style(&d.code).bold(),
+                style(&d.module).cyan(),
+                d.detail
+            );
+        }
+    }
+
+    let unfilled = report
+        .slots
+        .iter()
+        .filter(|s| s.filled_by.is_empty())
+        .count();
+    let errors = report
+        .diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .count();
+    eprintln!(
+        "\n{} slots · {} unfilled · {} error{}",
+        report.slots.len(),
+        unfilled,
+        errors,
+        if errors == 1 { "" } else { "s" }
+    );
+}

--- a/src/commands/module/capabilities/mod.rs
+++ b/src/commands/module/capabilities/mod.rs
@@ -151,6 +151,7 @@ fn print_human(source: &str, report: &Report) {
         for d in &report.diagnostics {
             let prefix = match d.severity {
                 Severity::Error => style("error:").red().bold(),
+                Severity::Warning => style("warning:").yellow().bold(),
                 Severity::Info => style("info: ").dim().bold(),
             };
             eprintln!(

--- a/src/commands/module/capabilities/resolve.rs
+++ b/src/commands/module/capabilities/resolve.rs
@@ -52,6 +52,17 @@ pub(crate) fn manifest_urls(internal_port: u16, slug: &str) -> [String; 3] {
 
 pub(crate) const MANIFEST_PATH: &str = "/__mirrorstack/platform/manifest";
 
+fn serving_tier(verdict: &str) -> Result<Option<Tier>, String> {
+    match verdict {
+        "tunnel" => Ok(Some(Tier::L)),
+        "deployed" => Ok(Some(Tier::D)),
+        "none" => Ok(None),
+        verdict => Err(format!(
+            "the platform returned unsupported serving verdict {verdict:?}"
+        )),
+    }
+}
+
 /// Walk `go.work` and pair each module `dev` would actually start with the
 /// internal port it would bind. Port assignment must mirror `dev::run_inner`
 /// exactly — only modules carrying a platform ID are started, and they take
@@ -176,6 +187,20 @@ pub(crate) fn tier_app(app_ref: &str) -> Result<(Vec<Resolved>, Vec<Unreachable>
         } else {
             install.slug.clone()
         };
+        let tier = match serving_tier(&install.serving) {
+            Ok(Some(tier)) => tier,
+            Ok(None) => {
+                unreachable.push(Unreachable {
+                    slug: name,
+                    reason: "the platform reports that this install has no serving tunnel or deployed version".into(),
+                });
+                continue;
+            }
+            Err(reason) => {
+                unreachable.push(Unreachable { slug: name, reason });
+                continue;
+            }
+        };
         let Some(value) = install.manifest else {
             unreachable.push(Unreachable {
                 slug: name,
@@ -200,7 +225,7 @@ pub(crate) fn tier_app(app_ref: &str) -> Result<(Vec<Resolved>, Vec<Unreachable>
                 manifest.id.clone()
             },
             version: install.installed_version,
-            tier: Tier::D,
+            tier,
             manifest,
         });
     }
@@ -242,6 +267,14 @@ mod tests {
             urls[2],
             "http://127.0.0.1:8080/_m/oauth-core/__mirrorstack/platform/manifest"
         );
+    }
+
+    #[test]
+    fn platform_serving_verdict_selects_the_runtime_tier() {
+        assert_eq!(serving_tier("tunnel"), Ok(Some(Tier::L)));
+        assert_eq!(serving_tier("deployed"), Ok(Some(Tier::D)));
+        assert_eq!(serving_tier("none"), Ok(None));
+        assert!(serving_tier("").unwrap_err().contains("unsupported"));
     }
 
     /// The internal port is positional, so a module in go.work that `dev` skips

--- a/src/commands/module/capabilities/resolve.rs
+++ b/src/commands/module/capabilities/resolve.rs
@@ -1,0 +1,282 @@
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+
+use crate::api::{self, ApiError};
+use crate::commands::dev::module_meta::{self, ModuleMeta};
+use crate::commands::dev::{
+    DEFAULT_MODULE_PORT, INTERNAL_PORT_BASE, MODULE_ROUTE_PREFIX, PROXY_PORT_DEFAULT,
+    platform_token_file, workspace,
+};
+use crate::commands::{DEFAULT_APPS_API_BASE, ENV_APPS_API_URL, resolve_base, session_expired};
+use crate::{credentials, http};
+
+use super::index::{Diagnostic, Resolved, Severity, Tier};
+use super::wire::Manifest;
+
+pub(crate) struct Unreachable {
+    pub slug: String,
+    pub reason: String,
+}
+
+pub(crate) fn request_headers(
+    mut request: reqwest::blocking::RequestBuilder,
+    root: &Path,
+    slug: &str,
+) -> reqwest::blocking::RequestBuilder {
+    if let Ok(token) = std::fs::read_to_string(platform_token_file(root, slug))
+        && !token.trim().is_empty()
+    {
+        request = request.header("X-MS-Platform-Token", token.trim());
+    }
+    if let Ok(secret) = std::env::var("MS_INTERNAL_SECRET")
+        && !secret.is_empty()
+    {
+        request = request.header("X-MS-Internal-Secret", secret);
+    }
+    request
+}
+
+/// Every address a co-located module's manifest can answer on, most direct
+/// first: its own internal runner port (the in-container path, and the path a
+/// host-side `dev --all` binds), then the dev-proxy as published to the host,
+/// then the dev-proxy's in-container port.
+pub(crate) fn manifest_urls(internal_port: u16, slug: &str) -> [String; 3] {
+    [
+        format!("http://127.0.0.1:{internal_port}{MANIFEST_PATH}"),
+        format!("http://127.0.0.1:{DEFAULT_MODULE_PORT}{MODULE_ROUTE_PREFIX}{slug}{MANIFEST_PATH}"),
+        format!("http://127.0.0.1:{PROXY_PORT_DEFAULT}{MODULE_ROUTE_PREFIX}{slug}{MANIFEST_PATH}"),
+    ]
+}
+
+pub(crate) const MANIFEST_PATH: &str = "/__mirrorstack/platform/manifest";
+
+/// Walk `go.work` and pair each module `dev` would actually start with the
+/// internal port it would bind. Port assignment must mirror `dev::run_inner`
+/// exactly — only modules carrying a platform ID are started, and they take
+/// 18080+ in go.work order — because an off-by-one here would read a SIBLING
+/// module's manifest and report its capabilities under the wrong name.
+/// Filesystem-only, so it is testable without a dev session.
+pub(crate) fn ready_modules(root: &Path) -> Result<Vec<(ModuleMeta, u16)>> {
+    let mut ready = Vec::new();
+    for module in workspace::discover_modules(root)? {
+        let Ok(meta) = module_meta::read_module_meta(&module.abs_dir, root) else {
+            continue;
+        };
+        if meta.id.is_empty() {
+            continue;
+        }
+        let port = INTERNAL_PORT_BASE + u16::try_from(ready.len()).unwrap_or(u16::MAX);
+        ready.push((meta, port));
+    }
+    Ok(ready)
+}
+
+pub(crate) fn tier_local(root: &Path) -> Result<(Vec<Resolved>, Vec<Unreachable>)> {
+    let client = http::client(Duration::from_secs(2))?;
+    let mut resolved = Vec::new();
+    let mut unreachable = Vec::new();
+    for (meta, internal) in ready_modules(root)? {
+        let urls = manifest_urls(internal, &meta.slug);
+        let mut manifest = None;
+        let mut last_status = None;
+        for url in &urls {
+            match request_headers(client.get(url), root, &meta.slug).send() {
+                Ok(resp) if resp.status() == reqwest::StatusCode::OK => {
+                    match resp.json::<Manifest>() {
+                        Ok(value) => {
+                            manifest = Some(value);
+                            break;
+                        }
+                        Err(error) => {
+                            last_status = Some(format!(
+                                "200 from {url} but the manifest did not parse: {error}"
+                            ));
+                        }
+                    }
+                }
+                // A 503 here is the SDK failing closed on an unreadable
+                // MS_PLATFORM_TOKEN_FILE — the state a non-tunnel `mirrorstack
+                // dev` leaves modules in, so say what unblocks it.
+                Ok(resp) if resp.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE => {
+                    last_status = Some(format!(
+                        "HTTP 503 from {url} — the module's internal routes are failing closed; run `mirrorstack dev --tunnel` so it gets a readable platform token"
+                    ));
+                }
+                Ok(resp) => {
+                    last_status = Some(format!("HTTP {} from {url}", resp.status().as_u16()))
+                }
+                Err(_) => {}
+            }
+        }
+        let Some(manifest) = manifest else {
+            let reason = last_status.unwrap_or_else(|| format!(
+                "no dev session answered on :{internal}, :{DEFAULT_MODULE_PORT} or :{PROXY_PORT_DEFAULT}"
+            ));
+            unreachable.push(Unreachable {
+                slug: meta.slug,
+                reason,
+            });
+            continue;
+        };
+        let keys: Vec<_> = manifest.versions.keys().cloned().collect();
+        let version = module_meta::latest_version(&keys)
+            .or(meta.version)
+            .unwrap_or_else(|| "unknown".into());
+        resolved.push(Resolved {
+            slug: if manifest.slug.is_empty() {
+                meta.slug
+            } else {
+                manifest.slug.clone()
+            },
+            id: if manifest.id.is_empty() {
+                meta.id
+            } else {
+                manifest.id.clone()
+            },
+            version: version.strip_prefix('v').unwrap_or(&version).into(),
+            tier: Tier::L,
+            manifest,
+        });
+    }
+    Ok((resolved, unreachable))
+}
+
+pub(crate) fn tier_app(app_ref: &str) -> Result<(Vec<Resolved>, Vec<Unreachable>)> {
+    let mut creds = credentials::load_or_login_hint()?;
+    let client = http::client(Duration::from_secs(15))?;
+    let apps_base = resolve_base(ENV_APPS_API_URL, DEFAULT_APPS_API_BASE);
+    // Both calls go through with_refresh_retry so an expired access token
+    // refreshes in place instead of surfacing as "session expired".
+    let app = match credentials::with_refresh_retry(&mut creds, |tok| {
+        api::get_app(&client, &apps_base, tok, app_ref)
+    }) {
+        Ok(Some(app)) => app,
+        Ok(None) => {
+            return Err(anyhow!(
+                "app '{app_ref}' not found (or you are not a member)"
+            ));
+        }
+        Err(ApiError::Unauthenticated) => return Err(session_expired()),
+        Err(error) => return Err(error.into()),
+    };
+    let installs = match credentials::with_refresh_retry(&mut creds, |tok| {
+        api::list_app_installs(&client, &apps_base, tok, &app.id)
+    }) {
+        Ok(installs) => installs,
+        Err(ApiError::Unauthenticated) => return Err(session_expired()),
+        Err(error) => return Err(error.into()),
+    };
+    let mut resolved = Vec::new();
+    let mut unreachable = Vec::new();
+    for install in installs {
+        let name = if install.slug.is_empty() {
+            install.name.clone()
+        } else {
+            install.slug.clone()
+        };
+        let Some(value) = install.manifest else {
+            unreachable.push(Unreachable {
+                slug: name,
+                reason: format!(
+                    "installed at {} but the platform stored no manifest for that version",
+                    install.installed_version
+                ),
+            });
+            continue;
+        };
+        let manifest: Manifest = serde_json::from_value(value)
+            .with_context(|| format!("decode stored manifest for {name}"))?;
+        resolved.push(Resolved {
+            slug: if manifest.slug.is_empty() {
+                install.slug
+            } else {
+                manifest.slug.clone()
+            },
+            id: if manifest.id.is_empty() {
+                install.module_id
+            } else {
+                manifest.id.clone()
+            },
+            version: install.installed_version,
+            tier: Tier::D,
+            manifest,
+        });
+    }
+    Ok((resolved, unreachable))
+}
+
+/// A co-located module we could not read becomes a `host_unresolvable`
+/// diagnostic so a `--json` consumer can tell "not co-located at all" from
+/// "co-located but not answering".
+pub(crate) fn unreachable_diagnostics(unreachable: &[Unreachable]) -> Vec<Diagnostic> {
+    unreachable
+        .iter()
+        .map(|u| Diagnostic {
+            severity: Severity::Error,
+            code: "host_unresolvable",
+            module: u.slug.clone(),
+            detail: u.reason.clone(),
+            related_host: Some(u.slug.clone()),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_urls_cover_the_runner_port_and_both_proxy_ports() {
+        let urls = manifest_urls(18081, "oauth-core");
+        assert_eq!(
+            urls[0],
+            "http://127.0.0.1:18081/__mirrorstack/platform/manifest"
+        );
+        assert_eq!(
+            urls[1],
+            "http://127.0.0.1:9080/_m/oauth-core/__mirrorstack/platform/manifest"
+        );
+        assert_eq!(
+            urls[2],
+            "http://127.0.0.1:8080/_m/oauth-core/__mirrorstack/platform/manifest"
+        );
+    }
+
+    /// The internal port is positional, so a module in go.work that `dev` skips
+    /// (no platform ID) must NOT consume a port — otherwise every module after
+    /// it is probed at its neighbour's address and reported under the wrong name.
+    #[test]
+    fn unregistered_modules_do_not_consume_an_internal_port() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join("go.work"),
+            "go 1.26\n\nuse (\n\t./unregistered\n\t./first\n\t./second\n)\n",
+        )
+        .unwrap();
+        for slug in ["unregistered", "first", "second"] {
+            std::fs::create_dir(root.join(slug)).unwrap();
+            std::fs::write(
+                root.join(slug).join("main.go"),
+                format!("package main\n\nvar c = ms.Config{{Slug: \"{slug}\"}}\n"),
+            )
+            .unwrap();
+        }
+        std::fs::write(
+            root.join(".env"),
+            "MS_MODULE_ID_FIRST=m-first\nMS_MODULE_ID_SECOND=m-second\n",
+        )
+        .unwrap();
+
+        let ready = ready_modules(root).expect("walk");
+        assert_eq!(
+            ready
+                .iter()
+                .map(|(m, port)| (m.slug.as_str(), *port))
+                .collect::<Vec<_>>(),
+            [("first", 18080), ("second", 18081)]
+        );
+    }
+}

--- a/src/commands/module/capabilities/schema.rs
+++ b/src/commands/module/capabilities/schema.rs
@@ -1,0 +1,156 @@
+use serde_json::Value;
+
+pub(crate) fn validate(schema: &Value, value: &Value) -> Result<(), String> {
+    validate_at(schema, value, "")
+}
+
+fn kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(n) if n.is_i64() || n.is_u64() => "integer",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn validate_at(schema: &Value, value: &Value, path: &str) -> Result<(), String> {
+    let Some(obj) = schema.as_object() else {
+        return Ok(());
+    };
+    if obj.is_empty() {
+        return Ok(());
+    }
+    if let Some(values) = obj.get("enum").and_then(Value::as_array)
+        && !values.contains(value)
+    {
+        return Err(format!("{path}: value is not in enum"));
+    }
+    // Go zero values and pointer fields commonly serialize as null, so null is
+    // accepted even when a generated SDK schema names a concrete type.
+    if !value.is_null()
+        && let Some(types) = obj.get("type")
+    {
+        let allowed: Vec<&str> = match types {
+            Value::String(s) => vec![s],
+            Value::Array(a) => a.iter().filter_map(Value::as_str).collect(),
+            _ => Vec::new(),
+        };
+        let actual = kind(value);
+        let matches = allowed
+            .iter()
+            .any(|t| *t == actual || (*t == "number" && actual == "integer"));
+        if !allowed.is_empty() && !matches {
+            return Err(format!(
+                "{path}: expected {}, got {actual}",
+                allowed.join(" or ")
+            ));
+        }
+    }
+    if let Some(map) = value.as_object() {
+        let properties = obj.get("properties").and_then(Value::as_object);
+        if let Some(required) = obj.get("required").and_then(Value::as_array) {
+            for name in required.iter().filter_map(Value::as_str) {
+                if !map.contains_key(name) {
+                    return Err(format!("{path}/{name}: required property is missing"));
+                }
+            }
+        }
+        if let Some(properties) = properties {
+            for (key, child_schema) in properties {
+                if let Some(child) = map.get(key) {
+                    validate_at(child_schema, child, &format!("{path}/{key}"))?;
+                }
+            }
+        }
+        if obj.get("additionalProperties") == Some(&Value::Bool(false))
+            && let Some(key) = map
+                .keys()
+                .find(|key| properties.is_none_or(|p| !p.contains_key(*key)))
+        {
+            return Err(format!("{path}/{key}: additional property is not allowed"));
+        }
+    }
+    if let (Some(items), Some(values)) = (obj.get("items"), value.as_array()) {
+        for (i, child) in values.iter().enumerate() {
+            validate_at(items, child, &format!("{path}/{i}"))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate;
+    use serde_json::json;
+
+    /// The shape an SDK-derived schema takes: typed properties, a required
+    /// list, a nested array item schema, and a keyword this validator does
+    /// not know (`futureKeyword`) that must be ignored rather than rejected.
+    fn schema() -> serde_json::Value {
+        json!({
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": ["integer", "null"]},
+                "tags": {"type": "array", "items": {"enum": ["a", "b"]}}
+            },
+            "additionalProperties": false,
+            "futureKeyword": 42
+        })
+    }
+
+    #[test]
+    fn accepts_a_conforming_payload() {
+        assert!(validate(&schema(), &json!({"name": "x", "age": null, "tags": ["a"]})).is_ok());
+    }
+
+    #[test]
+    fn missing_required_property_names_the_path() {
+        let err = validate(&schema(), &json!({"age": 1, "tags": []})).unwrap_err();
+        assert!(err.contains("/name"), "got {err}");
+    }
+
+    #[test]
+    fn wrong_property_type_names_the_expected_type() {
+        let err = validate(&schema(), &json!({"name": 3, "tags": []})).unwrap_err();
+        assert!(err.contains("expected string"), "got {err}");
+    }
+
+    #[test]
+    fn enum_violation_inside_an_array_names_the_index() {
+        let err = validate(&schema(), &json!({"name": "x", "tags": ["c"]})).unwrap_err();
+        assert!(err.contains("/tags/0"), "got {err}");
+    }
+
+    #[test]
+    fn additional_property_rejected_only_when_explicitly_closed() {
+        let err = validate(&schema(), &json!({"name": "x", "tags": [], "extra": 1})).unwrap_err();
+        assert!(err.contains("additional"), "got {err}");
+        // Same payload, schema silent on additionalProperties → allowed.
+        let open = json!({"type": "object", "properties": {"name": {"type": "string"}}});
+        assert!(validate(&open, &json!({"name": "x", "extra": 1})).is_ok());
+    }
+
+    #[test]
+    fn a_present_but_null_value_satisfies_a_concrete_type() {
+        // Go zero values and pointer fields serialize as null; treating that as
+        // a mismatch would fail every optional field.
+        let s = json!({"type": "object", "properties": {"name": {"type": "string"}}});
+        assert!(validate(&s, &json!({"name": null})).is_ok());
+    }
+
+    #[test]
+    fn an_integer_satisfies_a_number_type() {
+        assert!(validate(&json!({"type": "number"}), &json!(1)).is_ok());
+    }
+
+    #[test]
+    fn an_empty_or_non_object_schema_validates_anything() {
+        assert!(validate(&json!({}), &json!("anything")).is_ok());
+        assert!(validate(&json!("not schema"), &json!(1)).is_ok());
+    }
+}

--- a/src/commands/module/capabilities/schema.rs
+++ b/src/commands/module/capabilities/schema.rs
@@ -23,7 +23,7 @@ fn validate_at(
     schema: &Value,
     value: &Value,
     path: &str,
-    visited: &mut HashSet<String>,
+    visited: &mut HashSet<(String, String)>,
 ) -> Result<(), String> {
     let Some(obj) = schema.as_object() else {
         return Ok(());
@@ -37,12 +37,12 @@ fn validate_at(
             .ok_or_else(|| format!("{path}: $ref must be a string"))?;
         let target = resolve_ref(root, reference)
             .map_err(|reason| format!("{path}: cannot resolve $ref {reference:?}: {reason}"))?;
-        // Recursive Go types deliberately produce cyclic definitions. Once a
-        // reference repeats on the active path, the finite JSON value has
-        // already been checked as far as this schema can describe it.
-        if visited.insert(reference.into()) {
+        // Recursive values make progress by descending to a new JSON path.
+        // Only a repeated reference at the same position is a schema-only loop.
+        let progress = (reference.into(), path.into());
+        if visited.insert(progress.clone()) {
             let result = validate_at(root, target, value, path, visited);
-            visited.remove(reference);
+            visited.remove(&progress);
             result?;
         }
     }
@@ -184,6 +184,50 @@ mod tests {
             validate(
                 &schema("cyclic-node"),
                 &json!({"value": "root", "next": {"value": "child"}})
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn recursive_defs_reject_invalid_nested_values_at_their_path() {
+        let err = validate(
+            &schema("cyclic-node"),
+            &json!({
+                "value": "root",
+                "next": {
+                    "value": "child",
+                    "next": {"value": 42}
+                }
+            }),
+        )
+        .unwrap_err();
+        assert!(err.contains("/next/next/value"), "got {err}");
+        assert!(err.contains("expected string"), "got {err}");
+    }
+
+    #[test]
+    fn recursive_defs_accept_deeply_nested_valid_values() {
+        assert!(
+            validate(
+                &schema("cyclic-node"),
+                &json!({"value": "root", "next": {"value": 42}})
+            )
+            .is_err()
+        );
+        assert!(
+            validate(
+                &schema("cyclic-node"),
+                &json!({
+                    "value": "root",
+                    "next": {
+                        "value": "child",
+                        "next": {
+                            "value": "grandchild",
+                            "next": {"value": "great-grandchild"}
+                        }
+                    }
+                })
             )
             .is_ok()
         );

--- a/src/commands/module/capabilities/schema.rs
+++ b/src/commands/module/capabilities/schema.rs
@@ -1,7 +1,9 @@
+use std::collections::HashSet;
+
 use serde_json::Value;
 
 pub(crate) fn validate(schema: &Value, value: &Value) -> Result<(), String> {
-    validate_at(schema, value, "")
+    validate_at(schema, schema, value, "", &mut HashSet::new())
 }
 
 fn kind(value: &Value) -> &'static str {
@@ -16,12 +18,33 @@ fn kind(value: &Value) -> &'static str {
     }
 }
 
-fn validate_at(schema: &Value, value: &Value, path: &str) -> Result<(), String> {
+fn validate_at(
+    root: &Value,
+    schema: &Value,
+    value: &Value,
+    path: &str,
+    visited: &mut HashSet<String>,
+) -> Result<(), String> {
     let Some(obj) = schema.as_object() else {
         return Ok(());
     };
     if obj.is_empty() {
         return Ok(());
+    }
+    if let Some(reference) = obj.get("$ref") {
+        let reference = reference
+            .as_str()
+            .ok_or_else(|| format!("{path}: $ref must be a string"))?;
+        let target = resolve_ref(root, reference)
+            .map_err(|reason| format!("{path}: cannot resolve $ref {reference:?}: {reason}"))?;
+        // Recursive Go types deliberately produce cyclic definitions. Once a
+        // reference repeats on the active path, the finite JSON value has
+        // already been checked as far as this schema can describe it.
+        if visited.insert(reference.into()) {
+            let result = validate_at(root, target, value, path, visited);
+            visited.remove(reference);
+            result?;
+        }
     }
     if let Some(values) = obj.get("enum").and_then(Value::as_array)
         && !values.contains(value)
@@ -61,7 +84,7 @@ fn validate_at(schema: &Value, value: &Value, path: &str) -> Result<(), String> 
         if let Some(properties) = properties {
             for (key, child_schema) in properties {
                 if let Some(child) = map.get(key) {
-                    validate_at(child_schema, child, &format!("{path}/{key}"))?;
+                    validate_at(root, child_schema, child, &format!("{path}/{key}"), visited)?;
                 }
             }
         }
@@ -75,10 +98,26 @@ fn validate_at(schema: &Value, value: &Value, path: &str) -> Result<(), String> 
     }
     if let (Some(items), Some(values)) = (obj.get("items"), value.as_array()) {
         for (i, child) in values.iter().enumerate() {
-            validate_at(items, child, &format!("{path}/{i}"))?;
+            validate_at(root, items, child, &format!("{path}/{i}"), visited)?;
         }
     }
     Ok(())
+}
+
+fn resolve_ref<'a>(root: &'a Value, reference: &str) -> Result<&'a Value, String> {
+    if reference == "#" {
+        return Ok(root);
+    }
+    let Some(name) = reference.strip_prefix("#/$defs/") else {
+        return Err("only `#` and `#/$defs/NAME` references are supported".into());
+    };
+    if name.is_empty() || name.contains('/') {
+        return Err("definition name is empty or contains an unsupported JSON Pointer path".into());
+    }
+    let name = name.replace("~1", "/").replace("~0", "~");
+    root.get("$defs")
+        .and_then(|defs| defs.get(&name))
+        .ok_or_else(|| format!("definition {name:?} is missing"))
 }
 
 #[cfg(test)]
@@ -86,66 +125,92 @@ mod tests {
     use super::validate;
     use serde_json::json;
 
-    /// The shape an SDK-derived schema takes: typed properties, a required
-    /// list, a nested array item schema, and a keyword this validator does
-    /// not know (`futureKeyword`) that must be ignored rather than rejected.
-    fn schema() -> serde_json::Value {
-        json!({
-            "type": "object",
-            "required": ["name"],
-            "properties": {
-                "name": {"type": "string"},
-                "age": {"type": ["integer", "null"]},
-                "tags": {"type": "array", "items": {"enum": ["a", "b"]}}
-            },
-            "additionalProperties": false,
-            "futureKeyword": 42
-        })
+    /// Captured from the Go SDK reflector: validation keywords live under
+    /// `$defs`, while the slot schema root points at the reflected Go type.
+    fn manifest() -> serde_json::Value {
+        serde_json::from_str(include_str!(
+            "../../../../tests/fixtures/sdk-capabilities-manifest.json"
+        ))
+        .unwrap()
+    }
+
+    fn schema(slot: &str) -> serde_json::Value {
+        manifest()["provides"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|provide| provide["key"] == slot)
+            .unwrap()["payload"]
+            .clone()
     }
 
     #[test]
     fn accepts_a_conforming_payload() {
-        assert!(validate(&schema(), &json!({"name": "x", "age": null, "tags": ["a"]})).is_ok());
+        assert!(
+            validate(
+                &schema("user-detail-blocks"),
+                &json!({"title": "Roles", "bodyUrl": "/users/roles"})
+            )
+            .is_ok()
+        );
     }
 
     #[test]
     fn missing_required_property_names_the_path() {
-        let err = validate(&schema(), &json!({"age": 1, "tags": []})).unwrap_err();
-        assert!(err.contains("/name"), "got {err}");
+        let err = validate(
+            &schema("user-detail-blocks"),
+            &json!({"totally": "wrong", "nope": [1, 2, 3]}),
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("/title") || err.contains("/bodyUrl"),
+            "got {err}"
+        );
     }
 
     #[test]
     fn wrong_property_type_names_the_expected_type() {
-        let err = validate(&schema(), &json!({"name": 3, "tags": []})).unwrap_err();
-        assert!(err.contains("expected string"), "got {err}");
+        let err = validate(
+            &schema("users-table-columns"),
+            &json!("i am not even an object"),
+        )
+        .unwrap_err();
+        assert!(err.contains("expected object"), "got {err}");
     }
 
     #[test]
-    fn enum_violation_inside_an_array_names_the_index() {
-        let err = validate(&schema(), &json!({"name": "x", "tags": ["c"]})).unwrap_err();
-        assert!(err.contains("/tags/0"), "got {err}");
+    fn cyclic_defs_terminate() {
+        assert!(
+            validate(
+                &schema("cyclic-node"),
+                &json!({"value": "root", "next": {"value": "child"}})
+            )
+            .is_ok()
+        );
     }
 
     #[test]
-    fn additional_property_rejected_only_when_explicitly_closed() {
-        let err = validate(&schema(), &json!({"name": "x", "tags": [], "extra": 1})).unwrap_err();
-        assert!(err.contains("additional"), "got {err}");
-        // Same payload, schema silent on additionalProperties → allowed.
-        let open = json!({"type": "object", "properties": {"name": {"type": "string"}}});
-        assert!(validate(&open, &json!({"name": "x", "extra": 1})).is_ok());
+    fn unsupported_refs_are_loud() {
+        let err = validate(
+            &json!({"$ref": "https://example.com/schema.json"}),
+            &json!({}),
+        )
+        .unwrap_err();
+        assert!(err.contains("only `#` and `#/$defs/NAME`"), "got {err}");
     }
 
     #[test]
-    fn a_present_but_null_value_satisfies_a_concrete_type() {
-        // Go zero values and pointer fields serialize as null; treating that as
-        // a mismatch would fail every optional field.
-        let s = json!({"type": "object", "properties": {"name": {"type": "string"}}});
-        assert!(validate(&s, &json!({"name": null})).is_ok());
+    fn root_refs_terminate() {
+        assert!(validate(&json!({"$ref": "#"}), &json!({"anything": true})).is_ok());
     }
 
     #[test]
-    fn an_integer_satisfies_a_number_type() {
-        assert!(validate(&json!({"type": "number"}), &json!(1)).is_ok());
+    fn missing_refs_are_loud() {
+        let err = validate(&json!({"$ref": "#/$defs/Absent"}), &json!({})).unwrap_err();
+        assert!(
+            err.contains("definition \"Absent\" is missing"),
+            "got {err}"
+        );
     }
 
     #[test]

--- a/src/commands/module/capabilities/schema.rs
+++ b/src/commands/module/capabilities/schema.rs
@@ -1,140 +1,56 @@
-use std::collections::HashSet;
-
 use serde_json::Value;
 
-pub(crate) fn validate(schema: &Value, value: &Value) -> Result<(), String> {
-    validate_at(schema, schema, value, "", &mut HashSet::new())
-}
+pub(crate) struct Validator(jsonschema::Validator);
 
-fn kind(value: &Value) -> &'static str {
-    match value {
-        Value::Null => "null",
-        Value::Bool(_) => "boolean",
-        Value::Number(n) if n.is_i64() || n.is_u64() => "integer",
-        Value::Number(_) => "number",
-        Value::String(_) => "string",
-        Value::Array(_) => "array",
-        Value::Object(_) => "object",
+impl Validator {
+    pub(crate) fn compile(schema: &Value) -> Result<Self, String> {
+        jsonschema::draft202012::options()
+            .build(schema)
+            .map(Self)
+            .map_err(|error| format!("invalid schema: {error}"))
     }
-}
 
-fn validate_at(
-    root: &Value,
-    schema: &Value,
-    value: &Value,
-    path: &str,
-    visited: &mut HashSet<(String, String)>,
-) -> Result<(), String> {
-    let Some(obj) = schema.as_object() else {
-        return Ok(());
-    };
-    if obj.is_empty() {
-        return Ok(());
-    }
-    if let Some(reference) = obj.get("$ref") {
-        let reference = reference
-            .as_str()
-            .ok_or_else(|| format!("{path}: $ref must be a string"))?;
-        let target = resolve_ref(root, reference)
-            .map_err(|reason| format!("{path}: cannot resolve $ref {reference:?}: {reason}"))?;
-        // Recursive values make progress by descending to a new JSON path.
-        // Only a repeated reference at the same position is a schema-only loop.
-        let progress = (reference.into(), path.into());
-        if visited.insert(progress.clone()) {
-            let result = validate_at(root, target, value, path, visited);
-            visited.remove(&progress);
-            result?;
-        }
-    }
-    if let Some(values) = obj.get("enum").and_then(Value::as_array)
-        && !values.contains(value)
-    {
-        return Err(format!("{path}: value is not in enum"));
-    }
-    // Go zero values and pointer fields commonly serialize as null, so null is
-    // accepted even when a generated SDK schema names a concrete type.
-    if !value.is_null()
-        && let Some(types) = obj.get("type")
-    {
-        let allowed: Vec<&str> = match types {
-            Value::String(s) => vec![s],
-            Value::Array(a) => a.iter().filter_map(Value::as_str).collect(),
-            _ => Vec::new(),
-        };
-        let actual = kind(value);
-        let matches = allowed
-            .iter()
-            .any(|t| *t == actual || (*t == "number" && actual == "integer"));
-        if !allowed.is_empty() && !matches {
-            return Err(format!(
-                "{path}: expected {}, got {actual}",
-                allowed.join(" or ")
-            ));
-        }
-    }
-    if let Some(map) = value.as_object() {
-        let properties = obj.get("properties").and_then(Value::as_object);
-        if let Some(required) = obj.get("required").and_then(Value::as_array) {
-            for name in required.iter().filter_map(Value::as_str) {
-                if !map.contains_key(name) {
-                    return Err(format!("{path}/{name}: required property is missing"));
+    pub(crate) fn validate(&self, value: &Value) -> Result<(), String> {
+        self.0.validate(value).map_err(|error| {
+            let mut path = error.instance_path().to_string();
+            match error.kind() {
+                jsonschema::error::ValidationErrorKind::AdditionalProperties { unexpected } => {
+                    if let Some(property) = unexpected.first() {
+                        push_pointer_segment(&mut path, property);
+                    }
                 }
-            }
-        }
-        if let Some(properties) = properties {
-            for (key, child_schema) in properties {
-                if let Some(child) = map.get(key) {
-                    validate_at(root, child_schema, child, &format!("{path}/{key}"), visited)?;
+                jsonschema::error::ValidationErrorKind::Required { property } => {
+                    if let Some(property) = property.as_str() {
+                        push_pointer_segment(&mut path, property);
+                    }
                 }
+                _ => {}
             }
-        }
-        if obj.get("additionalProperties") == Some(&Value::Bool(false))
-            && let Some(key) = map
-                .keys()
-                .find(|key| properties.is_none_or(|p| !p.contains_key(*key)))
-        {
-            return Err(format!("{path}/{key}: additional property is not allowed"));
-        }
+            format!("{path}: {error}")
+        })
     }
-    if let (Some(items), Some(values)) = (obj.get("items"), value.as_array()) {
-        for (i, child) in values.iter().enumerate() {
-            validate_at(root, items, child, &format!("{path}/{i}"), visited)?;
-        }
-    }
-    Ok(())
 }
 
-fn resolve_ref<'a>(root: &'a Value, reference: &str) -> Result<&'a Value, String> {
-    if reference == "#" {
-        return Ok(root);
-    }
-    let Some(name) = reference.strip_prefix("#/$defs/") else {
-        return Err("only `#` and `#/$defs/NAME` references are supported".into());
-    };
-    if name.is_empty() || name.contains('/') {
-        return Err("definition name is empty or contains an unsupported JSON Pointer path".into());
-    }
-    let name = name.replace("~1", "/").replace("~0", "~");
-    root.get("$defs")
-        .and_then(|defs| defs.get(&name))
-        .ok_or_else(|| format!("definition {name:?} is missing"))
+fn push_pointer_segment(pointer: &mut String, segment: &str) {
+    pointer.push('/');
+    pointer.push_str(&segment.replace('~', "~0").replace('/', "~1"));
 }
 
 #[cfg(test)]
 mod tests {
-    use super::validate;
-    use serde_json::json;
+    use super::Validator;
+    use serde_json::{Value, json};
 
     /// Captured from the Go SDK reflector: validation keywords live under
     /// `$defs`, while the slot schema root points at the reflected Go type.
-    fn manifest() -> serde_json::Value {
+    fn manifest() -> Value {
         serde_json::from_str(include_str!(
             "../../../../tests/fixtures/sdk-capabilities-manifest.json"
         ))
         .unwrap()
     }
 
-    fn schema(slot: &str) -> serde_json::Value {
+    fn schema(slot: &str) -> Value {
         manifest()["provides"]
             .as_array()
             .unwrap()
@@ -142,6 +58,10 @@ mod tests {
             .find(|provide| provide["key"] == slot)
             .unwrap()["payload"]
             .clone()
+    }
+
+    fn validate(schema: &Value, value: &Value) -> Result<(), String> {
+        Validator::compile(schema)?.validate(value)
     }
 
     #[test]
@@ -175,7 +95,7 @@ mod tests {
             &json!("i am not even an object"),
         )
         .unwrap_err();
-        assert!(err.contains("expected object"), "got {err}");
+        assert!(err.contains("object"), "got {err}");
     }
 
     #[test]
@@ -203,7 +123,7 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("/next/next/value"), "got {err}");
-        assert!(err.contains("expected string"), "got {err}");
+        assert!(err.contains("string"), "got {err}");
     }
 
     #[test]
@@ -234,32 +154,59 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_refs_are_loud() {
-        let err = validate(
-            &json!({"$ref": "https://example.com/schema.json"}),
-            &json!({}),
-        )
-        .unwrap_err();
-        assert!(err.contains("only `#` and `#/$defs/NAME`"), "got {err}");
+    fn schema_valued_additional_properties_validate_map_values() {
+        let map_schema = json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#/$defs/StringMap",
+            "$defs": {
+                "StringMap": {
+                    "type": "object",
+                    "additionalProperties": {"$ref": "#/$defs/Entry"}
+                },
+                "Entry": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}},
+                    "required": ["value"],
+                    "additionalProperties": false
+                }
+            }
+        });
+
+        let err = validate(&map_schema, &json!({"first": {"value": 42}})).unwrap_err();
+        assert!(err.contains("/first/value"), "got {err}");
+        assert!(err.contains("string"), "got {err}");
     }
 
     #[test]
-    fn root_refs_terminate() {
-        assert!(validate(&json!({"$ref": "#"}), &json!({"anything": true})).is_ok());
+    fn additional_properties_false_rejects_unknown_keys() {
+        let err = validate(
+            &schema("auth-provider"),
+            &json!({"slug": "google", "unknown": true}),
+        )
+        .unwrap_err();
+        assert!(err.contains("/unknown"), "got {err}");
+        assert!(err.contains("Additional properties"), "got {err}");
+    }
+
+    #[test]
+    fn unsupported_refs_are_loud() {
+        let err = Validator::compile(&json!({"$ref": "https://example.com/schema.json"}))
+            .err()
+            .unwrap();
+        assert!(err.contains("invalid schema"), "got {err}");
     }
 
     #[test]
     fn missing_refs_are_loud() {
-        let err = validate(&json!({"$ref": "#/$defs/Absent"}), &json!({})).unwrap_err();
-        assert!(
-            err.contains("definition \"Absent\" is missing"),
-            "got {err}"
-        );
+        let err = Validator::compile(&json!({"$ref": "#/$defs/Absent"}))
+            .err()
+            .unwrap();
+        assert!(err.contains("invalid schema"), "got {err}");
+        assert!(err.contains("Absent"), "got {err}");
     }
 
     #[test]
-    fn an_empty_or_non_object_schema_validates_anything() {
+    fn an_empty_schema_validates_anything() {
         assert!(validate(&json!({}), &json!("anything")).is_ok());
-        assert!(validate(&json!("not schema"), &json!(1)).is_ok());
     }
 }

--- a/src/commands/module/capabilities/version.rs
+++ b/src/commands/module/capabilities/version.rs
@@ -1,0 +1,180 @@
+use crate::commands::dev::module_meta::{SemVer, parse_semver, semver_from_core};
+
+#[derive(Clone, Copy)]
+enum Op {
+    Eq,
+    Gt,
+    Ge,
+    Lt,
+    Le,
+}
+
+fn parse_partial(raw: &str) -> Option<(u64, u64, u64, usize, bool)> {
+    let raw = raw.strip_prefix('v').unwrap_or(raw);
+    let parts: Vec<_> = raw.split('.').collect();
+    if parts.is_empty() || parts.len() > 3 {
+        return None;
+    }
+    let mut nums = [0; 3];
+    let mut wildcard = false;
+    for (i, part) in parts.iter().enumerate() {
+        if *part == "x" || *part == "X" || *part == "*" {
+            wildcard = true;
+            return Some((nums[0], nums[1], nums[2], i, wildcard));
+        }
+        nums[i] = part.parse().ok()?;
+    }
+    Some((nums[0], nums[1], nums[2], parts.len(), wildcard))
+}
+
+fn compare(version: &SemVer, op: Op, bound: &SemVer) -> bool {
+    match op {
+        Op::Eq => version == bound,
+        Op::Gt => version > bound,
+        Op::Ge => version >= bound,
+        Op::Lt => version < bound,
+        Op::Le => version <= bound,
+    }
+}
+
+fn range(version: &SemVer, lo: SemVer, hi: SemVer) -> bool {
+    version >= &lo && version < &hi
+}
+
+fn matches_token(token: &str, version: &SemVer) -> bool {
+    let (op, operand) = [
+        (">=", Op::Ge),
+        ("<=", Op::Le),
+        ("==", Op::Eq),
+        (">", Op::Gt),
+        ("<", Op::Lt),
+        ("=", Op::Eq),
+    ]
+    .into_iter()
+    .find_map(|(prefix, op)| token.strip_prefix(prefix).map(|v| (Some(op), v)))
+    .unwrap_or((None, token));
+    if let Some(rest) = operand.strip_prefix('^') {
+        let Some((a, b, c, _, _)) = parse_partial(rest) else {
+            return true;
+        };
+        let hi = if a > 0 {
+            semver_from_core(a + 1, 0, 0)
+        } else if b > 0 {
+            semver_from_core(0, b + 1, 0)
+        } else {
+            semver_from_core(0, 0, c + 1)
+        };
+        return range(version, semver_from_core(a, b, c), hi);
+    }
+    if let Some(rest) = operand.strip_prefix('~') {
+        let Some((a, b, c, count, _)) = parse_partial(rest) else {
+            return true;
+        };
+        let hi = if count == 1 {
+            semver_from_core(a + 1, 0, 0)
+        } else {
+            semver_from_core(a, b + 1, 0)
+        };
+        return range(version, semver_from_core(a, b, c), hi);
+    }
+    let operand = operand.strip_prefix('v').unwrap_or(operand);
+    // A fully-qualified operand — including a prerelease like `0.1.0-dev`, which
+    // the partial parser cannot express — compares directly. Without this branch
+    // an exact prerelease pin would fall through to `parse_partial`, fail on the
+    // `-dev` segment, and never match even its own version.
+    if let Some(bound) = parse_semver(operand) {
+        return compare(version, op.unwrap_or(Op::Eq), &bound);
+    }
+    // An unrecognized token is lenient: a constraint we cannot read must not
+    // manufacture a version_skew error.
+    let Some((a, b, c, count, wildcard)) = parse_partial(operand) else {
+        return true;
+    };
+    if let Some(op) = op {
+        return compare(version, op, &semver_from_core(a, b, c));
+    }
+    // A bare wildcard (`x`, `*`) constrains nothing.
+    if wildcard && count == 0 {
+        return true;
+    }
+    if wildcard || count < 3 {
+        let hi = if count == 1 {
+            semver_from_core(a + 1, 0, 0)
+        } else {
+            semver_from_core(a, b + 1, 0)
+        };
+        return range(version, semver_from_core(a, b, 0), hi);
+    }
+    compare(version, Op::Eq, &semver_from_core(a, b, c))
+}
+
+/// Does `version` satisfy an npm-style constraint?
+pub(crate) fn satisfies(constraint: &str, version: &str) -> bool {
+    let Some(version) = parse_semver(version.strip_prefix('v').unwrap_or(version)) else {
+        return true;
+    };
+    let constraint = constraint.trim();
+    if constraint.is_empty() || matches!(constraint, "*" | "x" | "X") {
+        return true;
+    }
+    constraint.split("||").any(|alternative| {
+        alternative
+            .replace(',', " ")
+            .split_whitespace()
+            .all(|token| matches_token(token, &version))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::satisfies;
+
+    #[test]
+    fn operators_ranges_wildcards_and_or() {
+        assert!(satisfies(">=1.2.0 <2", "1.5.0"));
+        assert!(satisfies(">1.2 <=1.3.0", "1.3.0"));
+        assert!(!satisfies("<1.2.3", "1.2.3"));
+        assert!(satisfies("=1.2.3", "v1.2.3"));
+        assert!(satisfies("==v1.2.3", "1.2.3"));
+        assert!(satisfies("1", "1.9.0"));
+        assert!(satisfies("1.2", "1.2.8"));
+        assert!(satisfies("1.x", "1.8.0"));
+        assert!(satisfies("1.*", "1.8.0"));
+        assert!(satisfies("1.2.x", "1.2.9"));
+        assert!(satisfies("2 || ^1.2", "1.4.0"));
+    }
+
+    #[test]
+    fn caret_and_tilde_ranges() {
+        assert!(satisfies("^0.1", "0.1.9"));
+        assert!(!satisfies("^0.1", "0.2.0"));
+        assert!(satisfies("^0.0.3", "0.0.3"));
+        assert!(!satisfies("^0.0.3", "0.0.4"));
+        assert!(satisfies("^1.2", "1.9.0"));
+        assert!(!satisfies("^1.2", "2.0.0"));
+        assert!(satisfies("~1.2.3", "1.2.9"));
+        assert!(!satisfies("~1.2.3", "1.3.0"));
+        assert!(satisfies("~1.2", "1.2.9"));
+        assert!(satisfies("~1", "1.9.0"));
+    }
+
+    #[test]
+    fn prereleases_rank_below_their_release() {
+        assert!(!satisfies(">=1.0.0", "1.0.0-beta"));
+        // An exact prerelease pin must match itself — the partial parser cannot
+        // express `-dev`, so this exercises the full-SemVer branch.
+        assert!(satisfies("0.1.0-dev", "0.1.0-dev"));
+        assert!(!satisfies("0.1.0-dev", "0.1.0"));
+        assert!(satisfies(">=0.1.0-dev", "0.1.0"));
+    }
+
+    #[test]
+    fn unreadable_input_never_manufactures_a_mismatch() {
+        assert!(satisfies("^1", "not-semver"));
+        assert!(satisfies("whatever-this-is", "1.2.3"));
+        assert!(satisfies("", "1.2.3"));
+        assert!(satisfies("*", "1.2.3"));
+        assert!(satisfies("x", "1.2.3"));
+        assert!(satisfies(">=1.0.0 || x", "0.1.0"));
+    }
+}

--- a/src/commands/module/capabilities/wire.rs
+++ b/src/commands/module/capabilities/wire.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub(crate) struct Manifest {
+    pub id: String,
+    pub slug: String,
+    pub versions: BTreeMap<String, Value>,
+    pub provides: Vec<Slot>,
+    pub contributes_to: Vec<Contribution>,
+    pub dependencies: Vec<Dependency>,
+    pub exposes: Exposes,
+    pub permissions: Vec<Permission>,
+    pub events: Events,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub(crate) struct Slot {
+    pub key: String,
+    pub schema_tag: Option<String>,
+    pub payload: Option<Value>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub(crate) struct Contribution {
+    pub host: String,
+    pub slot: String,
+    pub payload: Option<Value>,
+    pub constraint: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub(crate) struct Dependency {
+    pub id: String,
+    pub version: Option<String>,
+    pub optional: bool,
+    pub tables: Vec<String>,
+    pub events: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub(crate) struct Exposes {
+    pub tables: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub(crate) struct Permission {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub(crate) struct Events {
+    pub emits: Vec<String>,
+    pub subscribes: BTreeMap<String, String>,
+}
+
+/// Split a module reference into (slug, optional version constraint).
+pub(crate) fn parse_ref(spec: &str) -> (String, Option<String>) {
+    let stripped = spec.strip_prefix('@').unwrap_or(spec);
+    let name = stripped.rsplit('/').next().unwrap_or(stripped);
+    match name.split_once('@') {
+        Some((slug, constraint)) => (slug.into(), Some(constraint.into())),
+        None => (name.into(), None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_ref;
+
+    #[test]
+    fn parses_supported_reference_forms() {
+        assert_eq!(parse_ref("oauth-core"), ("oauth-core".into(), None));
+        assert_eq!(
+            parse_ref("@mirrorstack/oauth-core"),
+            ("oauth-core".into(), None)
+        );
+        assert_eq!(
+            parse_ref("@mirrorstack/oauth-core@^0.1"),
+            ("oauth-core".into(), Some("^0.1".into()))
+        );
+        assert_eq!(
+            parse_ref("oauth-core@^0.1"),
+            ("oauth-core".into(), Some("^0.1".into()))
+        );
+        assert_eq!(
+            parse_ref("550e8400-e29b-41d4-a716-446655440000"),
+            ("550e8400-e29b-41d4-a716-446655440000".into(), None)
+        );
+    }
+}

--- a/src/commands/module/mod.rs
+++ b/src/commands/module/mod.rs
@@ -21,6 +21,7 @@ use crate::commands::dev::module_meta::{self, ModuleMeta};
 use crate::credentials;
 use crate::http;
 
+pub(crate) mod capabilities;
 mod changelog;
 mod readme;
 mod scaffold;
@@ -39,6 +40,8 @@ pub struct ModuleArgs {
 
 #[derive(Subcommand)]
 enum ModuleCommand {
+    /// Report the joined capability index for co-located or installed modules.
+    Capabilities(capabilities::CapabilitiesArgs),
     /// Create a new module on the platform and scaffold locally.
     /// Interactive by default; pass --yes for non-interactive use.
     Init(InitArgs),
@@ -111,6 +114,7 @@ pub struct DeployArgs {
 
 pub fn run(args: ModuleArgs) -> Result<()> {
     match args.command {
+        ModuleCommand::Capabilities(c) => capabilities::run(c),
         ModuleCommand::Init(i) => init(i),
         ModuleCommand::Register(r) => register(r),
         ModuleCommand::Deploy(d) => deploy(d),

--- a/tests/fixtures/sdk-capabilities-manifest.json
+++ b/tests/fixtures/sdk-capabilities-manifest.json
@@ -1,0 +1,77 @@
+{
+  "slug": "oauth-core",
+  "provides": [
+    {
+      "key": "auth-provider",
+      "payload": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$ref": "#/$defs/AuthProvider",
+        "$defs": {
+          "AuthProvider": {
+            "type": "object",
+            "properties": {
+              "slug": { "type": "string" },
+              "name": { "type": "string" }
+            },
+            "required": ["slug"],
+            "additionalProperties": false
+          }
+        }
+      }
+    },
+    {
+      "key": "user-detail-blocks",
+      "payload": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$ref": "#/$defs/UserDetailBlock",
+        "$defs": {
+          "UserDetailBlock": {
+            "type": "object",
+            "properties": {
+              "title": { "type": "string" },
+              "bodyUrl": { "type": "string" }
+            },
+            "required": ["title", "bodyUrl"],
+            "additionalProperties": false
+          }
+        }
+      }
+    },
+    {
+      "key": "users-table-columns",
+      "payload": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$ref": "#/$defs/UserTableColumn",
+        "$defs": {
+          "UserTableColumn": {
+            "type": "object",
+            "properties": {
+              "key": { "type": "string" },
+              "label": { "type": "string" }
+            },
+            "required": ["key", "label"],
+            "additionalProperties": false
+          }
+        }
+      }
+    },
+    {
+      "key": "cyclic-node",
+      "payload": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$ref": "#/$defs/Node",
+        "$defs": {
+          "Node": {
+            "type": "object",
+            "properties": {
+              "value": { "type": "string" },
+              "next": { "$ref": "#/$defs/Node" }
+            },
+            "required": ["value"],
+            "additionalProperties": false
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Why

`ms.ContributesTo(host, slot string, payload any)` takes free strings validated by nothing — not the compiler, not CI, not `mirrorstack dev`, not install.

On disk today:

```go
// ms-app-modules/users-profile/declare/register.go:35
ms.ContributesTo("oauth-core", "profile-store", profileStore{…})
```

`profile-store` exists nowhere in oauth-core — no `ms.Provide`, no constant, no read. Nothing caught it, because the host's `StoredContributions` returns an empty list for "typo'd slot name" exactly as it does for "not installed". The failure mode is silence. Meanwhile oauth-core's four unfilled UI slots (`users-quick-actions`, `users-overview-cards`, `user-detail-blocks`, `users-table-columns`) have been invisible for months.

The SDK manifest already carries the full declared surface, and `system/manifest.go` even claims *"The catalog (CLI in dev) validates each against the host's provides"*. That validation was specified and implemented nowhere. This is it.

Design doc: `docs-temp/module-capability-discovery/design.md` (layers 1 + 2; layer 0 is a separate SDK PR, see below).

## What

### Layer 1 — `mirrorstack module capabilities [--app <ref>] [--host <module>] [--json]`

Joins every resolvable module's manifest into one index: which host slots exist, who fills them, which are unfilled, what is broken.

Resolution mirrors how the **runtime** resolves — validating against local Go source while the runtime authorizes against the published manifest would be theatre:

| Tier | Source |
|---|---|
| **L** (default) | co-located `go.work` modules, manifests read **live** off the dev runner ports |
| **D** (`--app`) | the manifests **frozen at the versions installed in that app** |

Every resolved module, slot and fill is tagged with the tier and version it came from. An untagged capability answer is a bug.

Tier P (marketplace) is explicitly out of scope, but nothing here forecloses it — the payload schema in the JSON output exists precisely so a future third-party author can build a valid payload without reading host source.

### Layer 2 — `mirrorstack dev` boot check

`run_inner` polls each module's manifest (20 s budget, covers a cold `go build`), runs the same classification, and:

- `slot_unknown` / `payload_mismatch` → **fails loudly**, tears the session down, non-zero exit
- `host_unresolvable` → warning (a host outside the workspace is legal in dev)
- `slot_unfilled` → the coverage line, listing what nobody fills
- a module that never answers is **never** fatal — it may still be compiling

The existing `found N modules in go.work (N ready, N skipped)` startup output is untouched; the check appends after `dev-proxy listening`. Escape hatch: `--skip-capability-check` / `MS_SKIP_CAPABILITY_CHECK=1`.

### Diagnostics

| code | severity | meaning |
|---|---|---|
| `slot_unknown` | error | contribution targets a slot no resolvable host declares — **the `profile-store` bug** |
| `payload_mismatch` | error | payload fails the host slot's JSON Schema |
| `host_unresolvable` | error | host not found in any tier (or co-located but not answering) |
| `version_skew` | error | a constraint excluding the resolved host version, **or** a dependency naming a table/event the resolved version does not expose — the live 403 class |
| `slot_unfilled` | info | declared slot with no contributor (legal; the coverage report) |

Any error exits non-zero, so this works as a CI lint.

## Verified against fixture manifests modelling the real modules

```
✓ tier L · co-located go.work modules at …/ws

  oauth-core@0.1.0 [tier L]
    provides    auth-provider, users-quick-actions, users-overview-cards, user-detail-blocks, users-table-columns
    exposes     users
    permissions users.read, sessions.revoke
    emits       user.created

Slots
  ✓ oauth-core/auth-provider [0.1.0 tier L] filled by oauth-google@0.1.4 [tier L]
  ○ oauth-core/user-detail-blocks [0.1.0 tier L] unfilled
  ○ oauth-core/users-overview-cards [0.1.0 tier L] unfilled
  ○ oauth-core/users-quick-actions [0.1.0 tier L] unfilled
  ○ oauth-core/users-table-columns [0.1.0 tier L] unfilled

Diagnostics
  error: slot_unknown users-profile contributes to oauth-core/profile-store; oauth-core@0.1.0 (tier L) declares no such slot (declares: auth-provider, user-detail-blocks, users-overview-cards, users-quick-actions, users-table-columns)
  info:  slot_unfilled oauth-core slot oauth-core/user-detail-blocks is declared but no resolvable module contributes to it
  …

5 slots · 4 unfilled · 1 error
error: 1 capability error(s) — see the diagnostics above   (exit 1)
```

The other codes, same harness:

```
error: payload_mismatch oauth-google payload for oauth-core/auth-provider does not match the host slot schema: /slug: expected string, got integer
error: version_skew users-profile contributes to oauth-core/user-detail-blocks pinned ^2, but the resolved host is oauth-core@0.1.0 (tier L)
error: version_skew users-profile depends on oauth-core table "sessions", but oauth-core@0.1.0 (tier L) exposes users
```

## Cross-repo dependencies (none blocking)

- **`app-module-sdk`** is adding `SlotInfo.Payload` (JSON Schema derived from `Provide[T]`) and a versioned `ContributesTo` spec. This PR treats **both as OPTIONAL in the JSON** and lands independently — their absence raises nothing, pinned by `the_pre_schema_wire_shape_raises_nothing`. Once the SDK PR lands, `payload_mismatch` and the constraint arm of `version_skew` start firing with no CLI change.
- **`ms-app-modules/docker-compose.yml`** does not forward `MS_SKIP_CAPABILITY_CHECK`, so `--skip-capability-check` from *outer* mode is inert there until it adds `MS_SKIP_CAPABILITY_CHECK: \${MS_SKIP_CAPABILITY_CHECK:-}` next to `MS_INTERNAL_SECRET`. The CLI now says so rather than failing silently. Setting the env var directly on the runner works today.
- **api-platform install-time `version_skew` gate** is step 4 of the design's build order and is not in this PR.

## Notes for review

- **Tier L needs a live dev session** — that is the design (`go.work` + live dev session), not an oversight. And because `dev` always sets `MS_PLATFORM_TOKEN_FILE` while only `--tunnel` writes the file, a plain `mirrorstack dev` leaves modules 503-ing on internal routes; the unreachable reason says exactly that and points at `--tunnel`.
- **New top-level `mirrorstack module …`**, aliasing the same `ModuleArgs` the existing `mirrorstack apps module …` uses — one clap variant, zero duplicated logic, and the command reads as specified. The old nesting keeps working.
- `--app` resolves Tier D only (not L-then-D). Deliberate: with an explicit app the question is "what does this app actually have installed".
- **Dependencies never emit `host_unresolvable`** — depending on a module that is not co-located is normal, and spamming it would train people to ignore the report. Only contributions require their host to resolve.
- A JSON `null` value satisfies any declared type, and `required` only flags a *missing* key: Go zero values and pointers serialize as null, and `payload_mismatch` fails a dev boot, so it must not fire on legal payloads.
- Semver reuses the existing `module_meta::SemVer` model (one new 3-line `semver_from_core` helper) rather than adding a second one or a new crate.

## Verification

```
$ cargo build      → Finished
$ cargo test       → 294 passed; 0 failed
$ cargo clippy --all-targets -- -D warnings → Finished (clean)
$ cargo fmt --check → clean
```

Run outside any sandbox, on the worktree. 26 of those tests are new and cover the diagnostic classification against fixture manifests (known slot, unknown slot, unfilled slot, unresolvable host, payload mismatch, constraint skew, unexposed dependency table, pre-schema wire shape, ordering, host filter), the JSON Schema subset, the semver matcher, ref parsing, the internal-port assignment mirroring `dev::run_inner`, and the installs API call. No test needs a live dev session, a database, a network, or credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)