### PR TITLE
feat(module): cross-compile, package and upload the module artifact on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ mirrorstack login --no-browser # Sign in on SSH/headless (paste the code shown o
 mirrorstack logout             # Revoke the current session and wipe local credentials
 mirrorstack whoami             # Print the currently signed-in user
 mirrorstack app module init    # Register a new module on the platform
+mirrorstack module deploy      # Cross-compile Linux/arm64, package a bootstrap zip, and upload it
 mirrorstack app web deploy     # Deploy a static build directory to app hosting
 mirrorstack module capabilities         # Which host slots exist, who fills them, what is broken
 mirrorstack module capabilities --json  # …the same index, machine-readable

--- a/src/api.rs
+++ b/src/api.rs
@@ -497,6 +497,121 @@ pub fn set_module_deploy(
     })
 }
 
+/// One-time PUT instruction for a version's Lambda artifact, returned by
+/// [`create_module_artifact_upload`]. The platform owns the key outright —
+/// the CLI never proposes one, and nothing is echoed back at finalize.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)] // version_id / module_id / expires_at are part of the API surface
+pub struct ModuleArtifactUpload {
+    pub url: String,
+    pub key: String,
+    /// Headers the presigned URL expects — sent verbatim on the PUT, exactly
+    /// like an app deploy's `UploadTarget`.
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+    #[serde(default)]
+    pub version_id: String,
+    #[serde(default)]
+    pub module_id: String,
+    /// RFC3339 presign expiry — informational only (the PUT follows
+    /// immediately, so the CLI never acts on it).
+    #[serde(default)]
+    pub expires_at: String,
+}
+
+/// POST /v1/modules/{moduleId}/versions/{versionRef}/artifact — record a
+/// pending artifact for the version and mint its presigned PUT. Takes no
+/// body: size and digest are read off object storage at finalize, never
+/// declared by the caller. `version_ref` is the version UUID or the
+/// canonical SemVer string — path-safe verbatim ([0-9A-Za-z.+-] only), same
+/// as [`set_module_deploy`]. Owner-scoped; a module the caller doesn't own
+/// collapses to 404.
+pub fn create_module_artifact_upload(
+    http: &Client,
+    apps_base: &str,
+    access_token: &str,
+    module_id: &str,
+    version_ref: &str,
+) -> Result<ModuleArtifactUpload, ApiError> {
+    let resp = http
+        .post(artifact_endpoint(apps_base, module_id, version_ref, ""))
+        .bearer_auth(access_token)
+        .header("Accept", "application/json")
+        .send()?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp.json::<ModuleArtifactUpload>()?);
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(ApiError::Unauthenticated);
+    }
+    Err(envelope_error(resp))
+}
+
+/// The persisted verification state of one version's immutable Lambda zip.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)] // the whole row is the API surface; deploy only needs success
+pub struct ModuleArtifact {
+    pub key: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub size_bytes: u64,
+    #[serde(default)]
+    pub version_id: String,
+    #[serde(default)]
+    pub module_id: String,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: String,
+}
+
+/// POST /v1/modules/{moduleId}/versions/{versionRef}/artifact/finalize —
+/// HEAD-verify the uploaded object and mark it deployable. Also takes no
+/// body: the pending row from [`create_module_artifact_upload`] already
+/// holds the key, so there is nothing for the caller to supply (and nothing
+/// to spoof). `artifact_missing` / `artifact_invalid` /
+/// `artifact_storage_unconfigured` come back as `ApiError::Server`.
+pub fn finalize_module_artifact(
+    http: &Client,
+    apps_base: &str,
+    access_token: &str,
+    module_id: &str,
+    version_ref: &str,
+) -> Result<ModuleArtifact, ApiError> {
+    let resp = http
+        .post(artifact_endpoint(
+            apps_base,
+            module_id,
+            version_ref,
+            "/finalize",
+        ))
+        .bearer_auth(access_token)
+        .header("Accept", "application/json")
+        .send()?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp.json::<ModuleArtifact>()?);
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(ApiError::Unauthenticated);
+    }
+    Err(envelope_error(resp))
+}
+
+fn artifact_endpoint(apps_base: &str, module_id: &str, version_ref: &str, tail: &str) -> String {
+    format!(
+        "{}/v1/modules/{}/versions/{}/artifact{}",
+        apps_base.trim_end_matches('/'),
+        module_id,
+        version_ref,
+        tail
+    )
+}
+
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 pub struct App {

--- a/src/commands/module/artifact.rs
+++ b/src/commands/module/artifact.rs
@@ -22,9 +22,19 @@ use crate::http;
 
 use super::{deploy_error_hint, session_expired, with_spinner};
 
-/// AWS Lambda's ceiling for an S3-sourced deployment package, mirrored
-/// client-side so an oversize artifact fails locally before any bytes move.
+/// Client-side sanity cap on the packaged (compressed) zip, mirroring the
+/// platform's own finalize-time ceiling on the uploaded object so an oversize
+/// artifact fails locally before any bytes move.
+///
+/// Deliberately NOT described as an AWS limit: Lambda's 250 MB quota applies
+/// to the *unzipped* package, so a zip under this cap can still be rejected by
+/// Lambda, and one over it is not necessarily over Lambda's. This is our
+/// ceiling, not theirs.
 const MAX_ARTIFACT_BYTES: u64 = 250 * 1024 * 1024; // 250 MB
+
+/// The one artifact-flow error code that is not a failure: the platform in
+/// front of us has no artifact object store wired at all.
+const CODE_STORAGE_UNCONFIGURED: &str = "artifact_storage_unconfigured";
 
 /// A Lambda package can be large enough to need substantially longer than
 /// the JSON API client's timeout on a slow uplink.
@@ -39,11 +49,16 @@ const UPLOAD_TIMEOUT: Duration = Duration::from_secs(300);
 /// does) still produces a Graviton binary — the platform's native-binary
 /// guards assert `aarch64` and a host-arch build would only fail at cold
 /// start, in prod.
+///
+/// `-trimpath` because this binary leaves the developer's machine: without it
+/// the compiled paths and DWARF carry the absolute source tree (`/Users/…`,
+/// `/home/…`, module cache paths) into an artifact stored on the platform.
 pub(crate) fn build_bootstrap(dir: &Path) -> Result<(TempDir, PathBuf)> {
     let tmp = TempDir::new().context("create temp module build directory")?;
     let bootstrap = tmp.path().join("bootstrap");
     let output = Command::new("go")
         .arg("build")
+        .arg("-trimpath")
         .arg("-o")
         .arg(&bootstrap)
         .arg(".")
@@ -100,6 +115,17 @@ pub(crate) fn zip_bootstrap(bootstrap_path: &Path) -> Result<PathBuf> {
     Ok(zip_path)
 }
 
+/// Whether the artifact actually reached the platform's object store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShipOutcome {
+    /// Uploaded and finalized — the version is artifact-backed.
+    Shipped,
+    /// The platform answered `artifact_storage_unconfigured`: it has no
+    /// artifact store wired, so there is nothing to upload to. Not an error —
+    /// see the caller in `module::deploy` for why this stays non-fatal.
+    StorageUnconfigured,
+}
+
 /// Create the upload → PUT → finalize the packaged artifact against the
 /// real ceiling.
 ///
@@ -114,7 +140,7 @@ pub(crate) fn ship_artifact(
     module_id: &str,
     version_ref: &str,
     zip_path: &Path,
-) -> Result<()> {
+) -> Result<ShipOutcome> {
     ship_artifact_with_cap(
         api_client,
         apps_base,
@@ -145,36 +171,54 @@ fn ship_artifact_with_cap(
     version_ref: &str,
     zip_path: &Path,
     max_artifact_bytes: u64,
-) -> Result<()> {
+) -> Result<ShipOutcome> {
     let size = file_size(zip_path)?;
     guard_size(size, max_artifact_bytes)?;
 
-    with_spinner("Uploading artifact…", || {
-        let upload = api::create_module_artifact_upload(
+    // Both legs can answer `artifact_storage_unconfigured` (the platform's
+    // handler maps store absence to it on create-upload *and* finalize), so
+    // both are checked for it; every other code stays fatal.
+    let outcome = with_spinner("Uploading artifact…", || -> Result<ShipOutcome> {
+        let upload = match api::create_module_artifact_upload(
             api_client,
             apps_base,
             access_token,
             module_id,
             version_ref,
-        )
-        .map_err(api_error)?;
+        ) {
+            Ok(upload) => upload,
+            Err(error) if storage_unconfigured(&error) => {
+                return Ok(ShipOutcome::StorageUnconfigured);
+            }
+            Err(error) => return Err(api_error(error)),
+        };
         // Presigned URLs carry their own auth, so this PUT goes out on a
         // client with no bearer token and an upload-sized timeout.
         let upload_client = http::client(UPLOAD_TIMEOUT)?;
-        upload_one(&upload_client, &upload, zip_path)
+        upload_one(&upload_client, &upload, zip_path)?;
+        Ok(ShipOutcome::Shipped)
     })?;
+    if outcome == ShipOutcome::StorageUnconfigured {
+        return Ok(outcome);
+    }
 
-    with_spinner("Finalizing artifact…", || {
+    match with_spinner("Finalizing artifact…", || {
         api::finalize_module_artifact(api_client, apps_base, access_token, module_id, version_ref)
-            .map_err(api_error)
-    })?;
-    Ok(())
+    }) {
+        Ok(_) => Ok(ShipOutcome::Shipped),
+        Err(error) if storage_unconfigured(&error) => Ok(ShipOutcome::StorageUnconfigured),
+        Err(error) => Err(api_error(error)),
+    }
+}
+
+fn storage_unconfigured(error: &ApiError) -> bool {
+    matches!(error, ApiError::Server { code, .. } if code == CODE_STORAGE_UNCONFIGURED)
 }
 
 fn guard_size(size: u64, max_artifact_bytes: u64) -> Result<()> {
     if size > max_artifact_bytes {
         return Err(anyhow!(
-            "module artifact too large: {} (capped at {}, the same ceiling AWS Lambda enforces for an S3-sourced deployment package) — trim unused dependencies from the module",
+            "module artifact too large: {} (the packaged zip is capped at {}, matching the ceiling the platform enforces on the uploaded object) — trim unused dependencies from the module",
             human_bytes(size),
             human_bytes(max_artifact_bytes)
         ));
@@ -474,6 +518,46 @@ mod tests {
         let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("uploaded zip");
         assert_eq!(archive.len(), 1);
         assert_eq!(archive.by_index(0).expect("entry").name(), "bootstrap");
+    }
+
+    fn ship_against_create_upload_error(status: usize, code: &str) -> Result<ShipOutcome> {
+        let dir = TempDir::new().expect("temp dir");
+        let bootstrap = dir.path().join("bootstrap");
+        fs::write(&bootstrap, b"lambda bootstrap").expect("write bootstrap");
+        let zip_path = zip_bootstrap(&bootstrap).expect("zip bootstrap");
+        let mut server = Server::new();
+        let create = server
+            .mock("POST", "/v1/modules/module-id/versions/1.2.3/artifact")
+            .with_status(status)
+            .with_body(json!({"error": {"code": code, "message": "nope"}}).to_string())
+            .create();
+        let client = http::client(Duration::from_secs(15)).expect("client");
+        let result = ship_artifact(
+            &client,
+            &server.url(),
+            "AT",
+            "module-id",
+            "1.2.3",
+            &zip_path,
+        );
+        create.assert();
+        result
+    }
+
+    /// A platform with no artifact store (local prod-sim, bucket-less prod)
+    /// must not fail a deploy whose version record is already frozen.
+    #[test]
+    fn storage_unconfigured_is_reported_not_fatal() {
+        let outcome = ship_against_create_upload_error(503, "artifact_storage_unconfigured")
+            .expect("storage-unconfigured is not an error");
+        assert_eq!(outcome, ShipOutcome::StorageUnconfigured);
+    }
+
+    #[test]
+    fn other_artifact_errors_stay_fatal() {
+        let error = ship_against_create_upload_error(422, "artifact_invalid")
+            .expect_err("every other code still fails the deploy");
+        assert!(error.to_string().contains("artifact_invalid"), "{error}");
     }
 
     #[test]

--- a/src/commands/module/artifact.rs
+++ b/src/commands/module/artifact.rs
@@ -1,0 +1,485 @@
+//! Linux/arm64 module build, Lambda packaging, and artifact upload.
+//!
+//! A deploy first cross-compiles the module into the custom-runtime
+//! `bootstrap` executable, verifies the output matches the Graviton runtime,
+//! and writes the single-file Lambda zip. Only after the local size guard
+//! passes does the version-scoped create-upload → PUT → finalize flow begin.
+
+use std::fs::{self, File};
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use reqwest::blocking::Client;
+use tempfile::TempDir;
+use zip::ZipWriter;
+use zip::write::SimpleFileOptions;
+
+use crate::api::{self, ApiError};
+use crate::http;
+
+use super::{deploy_error_hint, session_expired, with_spinner};
+
+/// AWS Lambda's ceiling for an S3-sourced deployment package, mirrored
+/// client-side so an oversize artifact fails locally before any bytes move.
+const MAX_ARTIFACT_BYTES: u64 = 250 * 1024 * 1024; // 250 MB
+
+/// A Lambda package can be large enough to need substantially longer than
+/// the JSON API client's timeout on a slow uplink.
+const UPLOAD_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Cross-compile the module in `dir` to a Linux/arm64 static binary named
+/// `bootstrap` inside a fresh temp dir. The returned temp dir must remain
+/// alive until the returned path has been uploaded.
+///
+/// The three build vars are set explicitly rather than inherited so a
+/// developer whose shell already exports `GOARCH=amd64` (or a CI image that
+/// does) still produces a Graviton binary — the platform's native-binary
+/// guards assert `aarch64` and a host-arch build would only fail at cold
+/// start, in prod.
+pub(crate) fn build_bootstrap(dir: &Path) -> Result<(TempDir, PathBuf)> {
+    let tmp = TempDir::new().context("create temp module build directory")?;
+    let bootstrap = tmp.path().join("bootstrap");
+    let output = Command::new("go")
+        .arg("build")
+        .arg("-o")
+        .arg(&bootstrap)
+        .arg(".")
+        .current_dir(dir)
+        .env("GOOS", "linux")
+        .env("GOARCH", "arm64")
+        .env("CGO_ENABLED", "0")
+        .output();
+
+    let output = match output {
+        Ok(output) => output,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Err(anyhow!(
+                "Go toolchain required to deploy a module — install Go or run the deploy from a machine that has it"
+            ));
+        }
+        Err(error) => return Err(error).context("run Go compiler"),
+    };
+    if !output.status.success() {
+        let mut compiler_output = output.stderr;
+        compiler_output.extend_from_slice(&output.stdout);
+        return Err(anyhow!(
+            "Go build failed:\n{}",
+            String::from_utf8_lossy(&compiler_output).trim()
+        ));
+    }
+
+    assert_aarch64_elf(&bootstrap)?;
+    set_executable(&bootstrap)?;
+    Ok((tmp, bootstrap))
+}
+
+/// Zip `bootstrap_path` as the executable `bootstrap` entry at the archive
+/// root, writing the archive alongside the binary.
+///
+/// Both details are load-bearing for `provided.al2023`: the runtime looks for
+/// an entry named exactly `bootstrap` at the archive root (any directory
+/// prefix and the function never starts), and it must carry the executable
+/// bit — a 0644 entry fails at init with a permission error, which is the
+/// classic silent packaging failure this function exists to prevent.
+pub(crate) fn zip_bootstrap(bootstrap_path: &Path) -> Result<PathBuf> {
+    let zip_path = bootstrap_path.with_extension("zip");
+    let file = File::create(&zip_path).with_context(|| format!("create {}", zip_path.display()))?;
+    let mut zip = ZipWriter::new(file);
+    let options = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .unix_permissions(0o755);
+    zip.start_file("bootstrap", options)
+        .context("add bootstrap to module artifact")?;
+    let mut bootstrap =
+        File::open(bootstrap_path).with_context(|| format!("open {}", bootstrap_path.display()))?;
+    io::copy(&mut bootstrap, &mut zip).context("write bootstrap into module artifact")?;
+    zip.finish().context("finalize module artifact")?;
+    Ok(zip_path)
+}
+
+/// Create the upload → PUT → finalize the packaged artifact against the
+/// real ceiling.
+///
+/// Thin wrapper over [`ship_artifact_with_cap`] for the same reason
+/// `app::deploy::deploy_ssr` wraps its own: tests drive the identical
+/// upload path against a tiny cap instead of needing a genuine 250 MB
+/// fixture on disk to prove the guard rejects.
+pub(crate) fn ship_artifact(
+    api_client: &Client,
+    apps_base: &str,
+    access_token: &str,
+    module_id: &str,
+    version_ref: &str,
+    zip_path: &Path,
+) -> Result<()> {
+    ship_artifact_with_cap(
+        api_client,
+        apps_base,
+        access_token,
+        module_id,
+        version_ref,
+        zip_path,
+        MAX_ARTIFACT_BYTES,
+    )
+}
+
+/// Size of the packaged artifact, rejecting an oversize bundle here — before
+/// the deploy has recorded anything remotely — so the failure costs nothing
+/// but a local build. [`ship_artifact_with_cap`] re-checks at upload time;
+/// that copy is the enforcement point, this one is the early exit.
+pub(crate) fn packaged_size(zip_path: &Path) -> Result<u64> {
+    let size = file_size(zip_path)?;
+    guard_size(size, MAX_ARTIFACT_BYTES)?;
+    Ok(size)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ship_artifact_with_cap(
+    api_client: &Client,
+    apps_base: &str,
+    access_token: &str,
+    module_id: &str,
+    version_ref: &str,
+    zip_path: &Path,
+    max_artifact_bytes: u64,
+) -> Result<()> {
+    let size = file_size(zip_path)?;
+    guard_size(size, max_artifact_bytes)?;
+
+    with_spinner("Uploading artifact…", || {
+        let upload = api::create_module_artifact_upload(
+            api_client,
+            apps_base,
+            access_token,
+            module_id,
+            version_ref,
+        )
+        .map_err(api_error)?;
+        // Presigned URLs carry their own auth, so this PUT goes out on a
+        // client with no bearer token and an upload-sized timeout.
+        let upload_client = http::client(UPLOAD_TIMEOUT)?;
+        upload_one(&upload_client, &upload, zip_path)
+    })?;
+
+    with_spinner("Finalizing artifact…", || {
+        api::finalize_module_artifact(api_client, apps_base, access_token, module_id, version_ref)
+            .map_err(api_error)
+    })?;
+    Ok(())
+}
+
+fn guard_size(size: u64, max_artifact_bytes: u64) -> Result<()> {
+    if size > max_artifact_bytes {
+        return Err(anyhow!(
+            "module artifact too large: {} (capped at {}, the same ceiling AWS Lambda enforces for an S3-sourced deployment package) — trim unused dependencies from the module",
+            human_bytes(size),
+            human_bytes(max_artifact_bytes)
+        ));
+    }
+    Ok(())
+}
+
+fn api_error(error: ApiError) -> anyhow::Error {
+    match error {
+        ApiError::Server { code, message, .. } => {
+            anyhow!("{code}: {message}{hint}", hint = deploy_error_hint(&code))
+        }
+        ApiError::Unauthenticated => session_expired(),
+        other => other.into(),
+    }
+}
+
+/// One presigned PUT: the body is the archive verbatim and the headers are
+/// exactly what the platform handed back — nothing added (no bearer token;
+/// the signature IS the auth).
+fn upload_one(client: &Client, upload: &api::ModuleArtifactUpload, path: &Path) -> Result<()> {
+    let bytes = fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    let mut req = client.put(&upload.url).body(bytes);
+    for (name, value) in &upload.headers {
+        req = req.header(name.as_str(), value.as_str());
+    }
+    // `reqwest::Error` renders the URL it failed on, and this one carries a
+    // live signature. In a CI log that is a usable write credential until it
+    // expires, so strip the URL before the error can reach stderr.
+    let resp = req
+        .send()
+        .map_err(|error| anyhow!("presigned PUT failed: {}", error.without_url()))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = http::read_capped(resp).unwrap_or_default();
+        return Err(anyhow!(
+            "presigned PUT failed: HTTP {} {}",
+            status.as_u16(),
+            String::from_utf8_lossy(&body).trim()
+        ));
+    }
+    Ok(())
+}
+
+/// Size of a file on disk, without reading it — the only artifact fact the
+/// CLI needs, since the platform HEADs the uploaded object for size and
+/// digest at finalize rather than trusting a caller declaration.
+fn file_size(path: &Path) -> Result<u64> {
+    Ok(fs::metadata(path)
+        .with_context(|| format!("stat {}", path.display()))?
+        .len())
+}
+
+/// Refuse anything that isn't a 64-bit little-endian AArch64 ELF. A
+/// host-arch binary is a perfectly valid file that only fails at cold start
+/// in prod, so the check belongs here, next to the build that produced it.
+fn assert_aarch64_elf(path: &Path) -> Result<()> {
+    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut header = Vec::with_capacity(ELF_HEADER_PREFIX);
+    // `take` + `read_to_end` rather than one `read`: a single read is allowed
+    // to come back short, which would misreport a valid binary as non-ELF.
+    file.take(ELF_HEADER_PREFIX as u64)
+        .read_to_end(&mut header)
+        .with_context(|| format!("read ELF header from {}", path.display()))?;
+    assert_aarch64_elf_header(&header)
+}
+
+/// Bytes of the ELF header this check reads: through `e_machine` at 0x12.
+const ELF_HEADER_PREFIX: usize = 20;
+
+fn assert_aarch64_elf_header(header: &[u8]) -> Result<()> {
+    if header.len() < ELF_HEADER_PREFIX || header.get(..4) != Some(b"\x7fELF") {
+        return Err(anyhow!(
+            "built bootstrap is not an ELF executable; every MirrorStack Lambda is Graviton/arm64 and requires a 64-bit little-endian AArch64 ELF"
+        ));
+    }
+    let class = header[4];
+    let data = header[5];
+    let machine = u16::from_le_bytes([header[0x12], header[0x13]]);
+    if class != 2 || data != 1 || machine != 183 {
+        return Err(anyhow!(
+            "built bootstrap has ELF class {class}, data encoding {data}, machine {machine}; required class 2, little-endian encoding 1, machine 183 (AArch64/arm64), because every MirrorStack Lambda is Graviton/arm64"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+        .with_context(|| format!("chmod +x {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// `1023 B` / `4.2 KB` / `250.0 MB` — one decimal above bytes.
+pub(crate) fn human_bytes(n: u64) -> String {
+    const KB: f64 = 1024.0;
+    let n = n as f64;
+    if n < KB {
+        format!("{n:.0} B")
+    } else if n < KB * KB {
+        format!("{:.1} KB", n / KB)
+    } else {
+        format!("{:.1} MB", n / (KB * KB))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::{Cursor, Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Arc, Mutex};
+
+    use mockito::Server;
+    use serde_json::json;
+
+    type UploadCapture = Arc<Mutex<(String, Vec<u8>)>>;
+
+    fn elf_header(machine: u16) -> [u8; ELF_HEADER_PREFIX] {
+        let mut header = [0u8; ELF_HEADER_PREFIX];
+        header[..4].copy_from_slice(b"\x7fELF");
+        header[4] = 2;
+        header[5] = 1;
+        header[0x12..0x14].copy_from_slice(&machine.to_le_bytes());
+        header
+    }
+
+    #[test]
+    fn aarch64_guard_accepts_arm64_and_rejects_other_inputs() {
+        assert_aarch64_elf_header(&elf_header(183)).expect("AArch64 accepted");
+        let x86 = assert_aarch64_elf_header(&elf_header(62)).expect_err("x86 rejected");
+        assert!(x86.to_string().contains("arm64"));
+        let text = assert_aarch64_elf_header(b"not an elf").expect_err("text rejected");
+        assert!(text.to_string().contains("not an ELF"));
+    }
+
+    #[test]
+    fn zip_bootstrap_produces_lambda_root_entry() {
+        let dir = TempDir::new().expect("temp dir");
+        let bootstrap = dir.path().join("bootstrap");
+        fs::write(&bootstrap, b"binary contents").expect("write bootstrap");
+        let zip_path = zip_bootstrap(&bootstrap).expect("zip bootstrap");
+        let mut archive =
+            zip::ZipArchive::new(File::open(zip_path).expect("open zip")).expect("valid zip");
+        assert_eq!(archive.len(), 1);
+        let mut entry = archive.by_index(0).expect("bootstrap entry");
+        assert_eq!(entry.name(), "bootstrap");
+        assert_eq!(entry.unix_mode().map(|mode| mode & 0o777), Some(0o755));
+        let mut contents = Vec::new();
+        entry.read_to_end(&mut contents).expect("read entry");
+        assert!(!contents.is_empty());
+    }
+
+    #[test]
+    fn ship_guard_rejects_before_network() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("bootstrap.zip");
+        fs::write(&path, b"xx").expect("write artifact");
+        let client = http::client(Duration::from_secs(1)).expect("client");
+        let error = ship_artifact_with_cap(
+            &client,
+            "http://127.0.0.1:1",
+            "AT",
+            "module-id",
+            "1.0.0",
+            &path,
+            1,
+        )
+        .expect_err("oversize rejected");
+        assert!(error.to_string().contains("too large"));
+        assert!(error.to_string().contains("1 B"));
+    }
+
+    fn spawn_upload_capture() -> (String, UploadCapture) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind capture listener");
+        let port = listener.local_addr().expect("listener address").port();
+        let captured = Arc::new(Mutex::new((String::new(), Vec::new())));
+        let writer = Arc::clone(&captured);
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept upload");
+            let mut request = Vec::new();
+            let mut chunk = [0u8; 8192];
+            let header_end = loop {
+                let n = stream.read(&mut chunk).expect("read request");
+                assert!(n > 0);
+                request.extend_from_slice(&chunk[..n]);
+                if let Some(pos) = request.windows(4).position(|part| part == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            };
+            let headers = String::from_utf8_lossy(&request[..header_end]).to_string();
+            let length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            let mut body = request[header_end..].to_vec();
+            while body.len() < length {
+                let n = stream.read(&mut chunk).expect("read body");
+                assert!(n > 0);
+                body.extend_from_slice(&chunk[..n]);
+            }
+            *writer.lock().expect("capture mutex") = (headers, body);
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                .expect("write response");
+        });
+        (format!("http://127.0.0.1:{port}/upload"), captured)
+    }
+
+    #[test]
+    fn artifact_round_trip_creates_upload_puts_and_finalizes() {
+        let dir = TempDir::new().expect("temp dir");
+        let bootstrap = dir.path().join("bootstrap");
+        fs::write(&bootstrap, b"lambda bootstrap").expect("write bootstrap");
+        let zip_path = zip_bootstrap(&bootstrap).expect("zip bootstrap");
+        let size = fs::metadata(&zip_path).expect("artifact metadata").len();
+        let (upload_url, captured) = spawn_upload_capture();
+
+        let mut server = Server::new();
+        // Both calls are bodiless by contract: the platform owns the key and
+        // reads size/digest off the object itself, so there is nothing for
+        // the CLI to declare or echo.
+        let create = server
+            .mock("POST", "/v1/modules/module-id/versions/1.2.3/artifact")
+            .match_header("authorization", "Bearer AT")
+            .with_status(200)
+            .with_body(
+                json!({
+                    "version_id": "v-1",
+                    "module_id": "module-id",
+                    "key": "modules/module-id/versions/v-1/artifact.zip",
+                    "url": upload_url,
+                    "headers": {"Content-Type": "application/zip"},
+                    "expires_at": "2026-08-02T00:00:00Z"
+                })
+                .to_string(),
+            )
+            .create();
+        let finalize = server
+            .mock(
+                "POST",
+                "/v1/modules/module-id/versions/1.2.3/artifact/finalize",
+            )
+            .match_header("authorization", "Bearer AT")
+            .with_status(200)
+            .with_body(
+                json!({
+                    "version_id": "v-1",
+                    "module_id": "module-id",
+                    "key": "modules/module-id/versions/v-1/artifact.zip",
+                    "status": "ready",
+                    "size_bytes": size,
+                    "created_at": "2026-08-02T00:00:00Z",
+                    "updated_at": "2026-08-02T00:00:00Z"
+                })
+                .to_string(),
+            )
+            .create();
+        let client = http::client(Duration::from_secs(15)).expect("client");
+        ship_artifact(
+            &client,
+            &server.url(),
+            "AT",
+            "module-id",
+            "1.2.3",
+            &zip_path,
+        )
+        .expect("ship artifact");
+        create.assert();
+        finalize.assert();
+
+        let (headers, bytes) = captured.lock().expect("capture mutex").clone();
+        // The server-supplied headers must be replayed verbatim on the PUT.
+        assert!(
+            headers
+                .to_ascii_lowercase()
+                .contains("content-type: application/zip"),
+            "{headers}"
+        );
+        // …and the bearer token must never follow the presigned URL.
+        assert!(
+            !headers.to_ascii_lowercase().contains("authorization:"),
+            "{headers}"
+        );
+        let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("uploaded zip");
+        assert_eq!(archive.len(), 1);
+        assert_eq!(archive.by_index(0).expect("entry").name(), "bootstrap");
+    }
+
+    #[test]
+    fn human_bytes_formats() {
+        assert_eq!(human_bytes(512), "512 B");
+        assert_eq!(human_bytes(4302), "4.2 KB");
+        assert_eq!(human_bytes(MAX_ARTIFACT_BYTES), "250.0 MB");
+    }
+}

--- a/src/commands/module/artifact.rs
+++ b/src/commands/module/artifact.rs
@@ -124,6 +124,18 @@ pub(crate) enum ShipOutcome {
     /// artifact store wired, so there is nothing to upload to. Not an error —
     /// see the caller in `module::deploy` for why this stays non-fatal.
     StorageUnconfigured,
+    /// The route itself is absent — a 404 carrying no platform error
+    /// envelope. api-platform#440 is what mounts
+    /// `/v1/modules/{id}/versions/{ref}/artifact[/finalize]`; a platform build
+    /// that predates it has no such pattern at all, so chi's default handler
+    /// answers `404 page not found` as text/plain instead of the
+    /// `{"error":{"code":…}}` every real handler writes.
+    ///
+    /// Non-fatal for the same two reasons `StorageUnconfigured` is, plus a
+    /// third: such a platform also has no artifact gate on the deploy call
+    /// (#440 adds that too), so the deploy that follows still succeeds and
+    /// behaves exactly as it did before the CLI learned to upload.
+    EndpointsMissing,
 }
 
 /// Create the upload → PUT → finalize the packaged artifact against the
@@ -176,8 +188,14 @@ fn ship_artifact_with_cap(
     guard_size(size, max_artifact_bytes)?;
 
     // Both legs can answer `artifact_storage_unconfigured` (the platform's
-    // handler maps store absence to it on create-upload *and* finalize), so
-    // both are checked for it; every other code stays fatal.
+    // handler maps store absence to it on create-upload *and* finalize) and
+    // both are mounted by the same PR, so both are checked for both
+    // non-fatal shapes; every other code stays fatal.
+    //
+    // Checking the finalize leg for a missing route is not redundant with
+    // checking the create leg: the two calls are separate requests and can
+    // land on different platform builds mid-rollout, so create can succeed
+    // against a new build while finalize hits an old one.
     let outcome = with_spinner("Uploading artifact…", || -> Result<ShipOutcome> {
         let upload = match api::create_module_artifact_upload(
             api_client,
@@ -190,6 +208,9 @@ fn ship_artifact_with_cap(
             Err(error) if storage_unconfigured(&error) => {
                 return Ok(ShipOutcome::StorageUnconfigured);
             }
+            Err(error) if endpoints_missing(&error) => {
+                return Ok(ShipOutcome::EndpointsMissing);
+            }
             Err(error) => return Err(api_error(error)),
         };
         // Presigned URLs carry their own auth, so this PUT goes out on a
@@ -198,7 +219,7 @@ fn ship_artifact_with_cap(
         upload_one(&upload_client, &upload, zip_path)?;
         Ok(ShipOutcome::Shipped)
     })?;
-    if outcome == ShipOutcome::StorageUnconfigured {
+    if outcome != ShipOutcome::Shipped {
         return Ok(outcome);
     }
 
@@ -207,12 +228,32 @@ fn ship_artifact_with_cap(
     }) {
         Ok(_) => Ok(ShipOutcome::Shipped),
         Err(error) if storage_unconfigured(&error) => Ok(ShipOutcome::StorageUnconfigured),
+        Err(error) if endpoints_missing(&error) => Ok(ShipOutcome::EndpointsMissing),
         Err(error) => Err(api_error(error)),
     }
 }
 
 fn storage_unconfigured(error: &ApiError) -> bool {
     matches!(error, ApiError::Server { code, .. } if code == CODE_STORAGE_UNCONFIGURED)
+}
+
+/// A 404 that did **not** carry the platform's `{"error":{…}}` envelope —
+/// nothing routed the request at all.
+///
+/// That absence is the whole discriminator, and it is reliable: `httputil`
+/// writes the envelope on every response it produces, so the artifact routes'
+/// own 404s (module / version / pending-row not found) always arrive as
+/// `ApiError::Server { code: "not_found", .. }`. Only an unrouted path falls
+/// through to chi's default `404 page not found`, which fails to parse as an
+/// envelope and lands in `ApiError::Unexpected`.
+///
+/// Reading this as "the platform predates the artifact endpoints" rather than
+/// "the base URL is wrong" is safe because `module deploy` has already made
+/// authenticated calls to other `/v1/modules` routes on this same base (the
+/// module lookup and the version record) before it ever ships an artifact — a
+/// bad base URL fails long before here.
+fn endpoints_missing(error: &ApiError) -> bool {
+    matches!(error, ApiError::Unexpected { status, .. } if *status == 404)
 }
 
 fn guard_size(size: u64, max_artifact_bytes: u64) -> Result<()> {
@@ -520,7 +561,11 @@ mod tests {
         assert_eq!(archive.by_index(0).expect("entry").name(), "bootstrap");
     }
 
-    fn ship_against_create_upload_error(status: usize, code: &str) -> Result<ShipOutcome> {
+    /// Drive the whole ship flow against a create-upload leg that answers
+    /// `status` with `body` verbatim — the body shape is the point, since a
+    /// platform error envelope and an unrouted 404 are told apart by nothing
+    /// else.
+    fn ship_against_create_upload_body(status: usize, body: &str) -> Result<ShipOutcome> {
         let dir = TempDir::new().expect("temp dir");
         let bootstrap = dir.path().join("bootstrap");
         fs::write(&bootstrap, b"lambda bootstrap").expect("write bootstrap");
@@ -529,7 +574,7 @@ mod tests {
         let create = server
             .mock("POST", "/v1/modules/module-id/versions/1.2.3/artifact")
             .with_status(status)
-            .with_body(json!({"error": {"code": code, "message": "nope"}}).to_string())
+            .with_body(body)
             .create();
         let client = http::client(Duration::from_secs(15)).expect("client");
         let result = ship_artifact(
@@ -544,6 +589,13 @@ mod tests {
         result
     }
 
+    fn ship_against_create_upload_error(status: usize, code: &str) -> Result<ShipOutcome> {
+        ship_against_create_upload_body(
+            status,
+            &json!({"error": {"code": code, "message": "nope"}}).to_string(),
+        )
+    }
+
     /// A platform with no artifact store (local prod-sim, bucket-less prod)
     /// must not fail a deploy whose version record is already frozen.
     #[test]
@@ -553,11 +605,83 @@ mod tests {
         assert_eq!(outcome, ShipOutcome::StorageUnconfigured);
     }
 
+    /// A platform build that predates the artifact routes doesn't answer
+    /// `artifact_storage_unconfigured` — it doesn't route the request at all,
+    /// and chi's default handler writes this exact plain-text body. Reported,
+    /// and distinctly from the 503, but not fatal: that platform has no
+    /// artifact gate on the deploy call either, so the deploy still lands.
+    #[test]
+    fn missing_artifact_routes_are_reported_not_fatal() {
+        let outcome = ship_against_create_upload_body(404, "404 page not found\n")
+            .expect("a platform without the routes is not an error");
+        assert_eq!(outcome, ShipOutcome::EndpointsMissing);
+    }
+
+    /// …and the enveloped 404 the routes themselves emit (module, version or
+    /// pending row not found) must NOT be mistaken for the routes being
+    /// absent. Same status, opposite verdict — the envelope is the only
+    /// discriminator, so it is asserted directly.
+    #[test]
+    fn enveloped_not_found_stays_fatal() {
+        let error = ship_against_create_upload_error(404, "not_found")
+            .expect_err("a real not_found still fails the deploy");
+        assert!(error.to_string().contains("not_found"), "{error}");
+    }
+
     #[test]
     fn other_artifact_errors_stay_fatal() {
         let error = ship_against_create_upload_error(422, "artifact_invalid")
             .expect_err("every other code still fails the deploy");
         assert!(error.to_string().contains("artifact_invalid"), "{error}");
+    }
+
+    /// Create can succeed against a new platform build while finalize lands
+    /// on an old one mid-rollout, so the finalize leg carries the same arm.
+    #[test]
+    fn missing_finalize_route_is_reported_not_fatal() {
+        let dir = TempDir::new().expect("temp dir");
+        let bootstrap = dir.path().join("bootstrap");
+        fs::write(&bootstrap, b"lambda bootstrap").expect("write bootstrap");
+        let zip_path = zip_bootstrap(&bootstrap).expect("zip bootstrap");
+        let (upload_url, _captured) = spawn_upload_capture();
+
+        let mut server = Server::new();
+        let create = server
+            .mock("POST", "/v1/modules/module-id/versions/1.2.3/artifact")
+            .with_status(200)
+            .with_body(
+                json!({
+                    "version_id": "v-1",
+                    "module_id": "module-id",
+                    "key": "modules/module-id/versions/v-1/artifact.zip",
+                    "url": upload_url,
+                    "headers": {"Content-Type": "application/zip"},
+                    "expires_at": "2026-08-02T00:00:00Z"
+                })
+                .to_string(),
+            )
+            .create();
+        let finalize = server
+            .mock(
+                "POST",
+                "/v1/modules/module-id/versions/1.2.3/artifact/finalize",
+            )
+            .with_status(404)
+            .with_body("404 page not found\n")
+            .create();
+        let client = http::client(Duration::from_secs(15)).expect("client");
+        let outcome = ship_artifact(
+            &client,
+            &server.url(),
+            "AT",
+            "module-id",
+            "1.2.3",
+            &zip_path,
+        )
+        .expect("a platform without the finalize route is not an error");
+        create.assert();
+        finalize.assert();
+        assert_eq!(outcome, ShipOutcome::EndpointsMissing);
     }
 
     #[test]

--- a/src/commands/module/mod.rs
+++ b/src/commands/module/mod.rs
@@ -877,8 +877,14 @@ fn record_error_hint(code: &str) -> &'static str {
 
 fn deploy_error_hint(code: &str) -> &'static str {
     match code {
+        // Three routes collapse onto this one code, and api-platform#440
+        // gives each its own message ("module not found", "version not found
+        // for this module", "artifact upload not found"), so the hint must
+        // not name a cause the message hasn't. It only carries the remedy,
+        // which is the same for all three except when the module itself is
+        // the missing record.
         "not_found" => {
-            " (the version record vanished mid-deploy — re-run `mirrorstack app module deploy`)"
+            " (the message says which record the platform couldn't find — re-run `mirrorstack app module deploy` to re-create the version record and its upload; if the module is what's missing, `mirrorstack app module register` it first)"
         }
         // The platform derives invoke_target from the module's own slug and
         // only sanity-checks that derivation — this can't be triggered by
@@ -1239,7 +1245,18 @@ mod tests {
 
     #[test]
     fn deploy_error_hint_for_known_codes() {
-        assert!(deploy_error_hint("not_found").contains("mirrorstack app module deploy"));
+        // `not_found` has three emitters on these routes, so the hint may
+        // carry only the remedy — naming one of the three would be wrong for
+        // the other two.
+        let not_found = deploy_error_hint("not_found");
+        assert!(
+            not_found.contains("mirrorstack app module deploy"),
+            "{not_found}"
+        );
+        assert!(
+            not_found.contains("mirrorstack app module register"),
+            "{not_found}"
+        );
         assert!(deploy_error_hint("invoke_target_invalid").contains("platform"));
         assert!(deploy_error_hint("status_invalid").contains("--status"));
         assert!(deploy_error_hint("artifact_missing").contains("module deploy"));

--- a/src/commands/module/mod.rs
+++ b/src/commands/module/mod.rs
@@ -21,6 +21,7 @@ use crate::commands::dev::module_meta::{self, ModuleMeta};
 use crate::credentials;
 use crate::http;
 
+mod artifact;
 pub(crate) mod capabilities;
 mod changelog;
 mod readme;
@@ -51,10 +52,13 @@ enum ModuleCommand {
     /// writes the assigned ID back under that module's key in .env.
     Register(RegisterArgs),
     /// Deploy the version your code declares (the newest Config.Versions
-    /// key in ./main.go). Records the version with its CHANGELOG.md section
-    /// first when it isn't recorded yet — records are immutable, bump the
-    /// key to ship a new entry. The prod transport target is derived by the
-    /// platform from the module's own identity, never supplied by the caller.
+    /// key in ./main.go). Cross-compiles the module for Linux/arm64 and
+    /// packages it as a Lambda `bootstrap` zip, records the version with its
+    /// CHANGELOG.md section when it isn't recorded yet — records are
+    /// immutable, bump the key to ship a new entry — then uploads the
+    /// artifact and points the deploy at it. The prod transport target is
+    /// derived by the platform from the module's own identity, never
+    /// supplied by the caller.
     Deploy(DeployArgs),
 }
 
@@ -489,6 +493,23 @@ fn deploy(args: DeployArgs) -> Result<()> {
         }
     }
 
+    // Build, package and size-check before anything irreversible happens: a
+    // compile error or an oversize bundle must not first freeze an immutable
+    // version record. Same posture as `app web deploy`, which packages and
+    // checks the SSR bundle before it creates the deploy.
+    let (_artifact_dir, bootstrap) =
+        with_spinner("Building module…", || artifact::build_bootstrap(&dir))?;
+    let zip_path = artifact::zip_bootstrap(&bootstrap)?;
+    let artifact_size = artifact::packaged_size(&zip_path)?;
+
+    eprintln!(
+        "  {} {} → {} (arm64 bundle, {})",
+        style("Deploying:").dim(),
+        style(dir.display()).bold(),
+        style(format!("{slug}@{version}")).cyan().bold(),
+        artifact::human_bytes(artifact_size)
+    );
+
     ensure_version_recorded(
         &client,
         &apps_base,
@@ -499,6 +520,25 @@ fn deploy(args: DeployArgs) -> Result<()> {
         &version,
         &dir,
     )?;
+
+    // Version-scoped, so it can only run once the record above exists.
+    // `_artifact_dir` (the temp dir backing `zip_path`) stays alive across
+    // this call by still being in scope — dropping it earlier would delete
+    // the archive out from under the upload.
+    artifact::ship_artifact(
+        &client,
+        &apps_base,
+        &creds.access_token,
+        &module.id,
+        &version,
+        &zip_path,
+    )?;
+    eprintln!(
+        "{} uploaded {} ({})",
+        ok_mark(),
+        style(format!("{slug}@{version}")).cyan().bold(),
+        artifact::human_bytes(artifact_size)
+    );
 
     let result = with_spinner("Deploying…", || {
         api::set_module_deploy(
@@ -798,6 +838,15 @@ fn deploy_error_hint(code: &str) -> &'static str {
             " (the platform couldn't derive a valid deploy target from this module's slug — this is a platform-side issue, not something to fix locally)"
         }
         "status_invalid" => " (--status must be one of: active, draining, disabled)",
+        "artifact_missing" => {
+            " (the upload didn't land in object storage — re-run `mirrorstack module deploy`)"
+        }
+        "artifact_invalid" => {
+            " (the platform rejected the uploaded zip — it must contain an executable `bootstrap` at the archive root and stay under 250.0 MB)"
+        }
+        "artifact_storage_unconfigured" => {
+            " (module artifact storage is not configured on the platform — this is a platform-side issue, not something to fix locally)"
+        }
         _ => "",
     }
 }
@@ -1116,6 +1165,9 @@ mod tests {
         assert!(deploy_error_hint("not_found").contains("mirrorstack app module deploy"));
         assert!(deploy_error_hint("invoke_target_invalid").contains("platform"));
         assert!(deploy_error_hint("status_invalid").contains("--status"));
+        assert!(deploy_error_hint("artifact_missing").contains("module deploy"));
+        assert!(deploy_error_hint("artifact_invalid").contains("bootstrap"));
+        assert!(deploy_error_hint("artifact_storage_unconfigured").contains("platform"));
         assert_eq!(deploy_error_hint("something_else"), "");
     }
 

--- a/src/commands/module/mod.rs
+++ b/src/commands/module/mod.rs
@@ -541,8 +541,16 @@ fn deploy(args: DeployArgs) -> Result<()> {
     //      strands that row: the version exists, nothing is deployed, and a
     //      re-run just 409-skips the record and fails the same way.
     //
+    // A 404 with no error envelope — the artifact routes not existing at all —
+    // is a WARN for the same two reasons, plus a third: a platform that
+    // predates those routes also predates #440's deploy gate, so the
+    // `set_module_deploy` below still succeeds and the deploy ends up exactly
+    // where it did before this CLI learned to upload. Failing instead would
+    // turn "your platform is a version behind" into "you cannot deploy at
+    // all", with no flag to opt out of the upload.
+    //
     // Every other artifact error stays fatal — `ship_artifact` only collapses
-    // this one code.
+    // these two shapes.
     let shipped = artifact::ship_artifact(
         &client,
         &apps_base,
@@ -566,6 +574,17 @@ fn deploy(args: DeployArgs) -> Result<()> {
             );
             eprintln!(
                 "  {} the version was recorded and the deploy continues, but it is not artifact-backed — the module runs from whatever transport this environment already resolves (local prod-sim, or an existing production function).",
+                style("note:").dim(),
+            );
+        }
+        artifact::ShipOutcome::EndpointsMissing => {
+            eprintln!(
+                "{} no artifact was uploaded for {}: this platform build has no module-artifact endpoints (the upload route answered 404).",
+                warn_prefix(),
+                style(format!("{slug}@{version}")).cyan().bold(),
+            );
+            eprintln!(
+                "  {} upgrade the platform to a build that serves them. Until then the deploy continues without an artifact — the version is recorded and the module runs from whatever transport this environment already resolves.",
                 style("note:").dim(),
             );
         }
@@ -887,10 +906,23 @@ fn deploy_error_hint(code: &str) -> &'static str {
         "artifact_storage_unconfigured" => {
             " (module artifact storage is not configured on the platform — expected for local prod-sim and bucket-less environments, not something to fix locally)"
         }
+        // 409 from finalize only. A second `module deploy` of this same
+        // version presigned a fresh upload while this one was verifying, so
+        // the platform refuses to certify a readiness verdict for bytes that
+        // are no longer the ones behind the key.
+        "artifact_superseded" => {
+            " (another deploy of this version started a new upload — let that one finish, or re-run `mirrorstack module deploy` to upload and finalize again)"
+        }
         // What `httputil.Conflict` emits when a deploy is attempted for a
         // version whose artifact never finalized.
         "conflict" => {
             " (the artifact for this version isn't finalized — re-run `mirrorstack module deploy` so the upload completes before the deploy)"
+        }
+        // The platform's catch-all 500. Nothing local produced it — a presign
+        // failure or a database error behind the artifact row would both land
+        // here — so rebuilding and re-uploading changes nothing.
+        "internal_error" => {
+            " (the platform failed on its side — retry; if it persists it is a platform issue, not something to fix locally)"
         }
         _ => "",
     }
@@ -1218,7 +1250,31 @@ mod tests {
         assert!(!invalid.contains("bootstrap"), "{invalid}");
         assert!(deploy_error_hint("artifact_storage_unconfigured").contains("platform"));
         assert!(deploy_error_hint("conflict").contains("finalized"));
+        assert!(deploy_error_hint("artifact_superseded").contains("another deploy"));
+        assert!(deploy_error_hint("internal_error").contains("platform"));
         assert_eq!(deploy_error_hint("something_else"), "");
+    }
+
+    /// Every error code api-platform#440 can emit on the three platform
+    /// routes `module deploy` calls — create-upload, finalize and deploy —
+    /// must carry a hint. A bare `code: message` line with no explanation is
+    /// exactly what this table exists to prevent, so the coverage is asserted
+    /// rather than left to review.
+    #[test]
+    fn deploy_error_hint_covers_every_platform_code() {
+        for code in [
+            "not_found",                     // 404 — module, version, or pending artifact row
+            "artifact_missing",              // 422 — finalize, object absent
+            "artifact_invalid",              // 422 — finalize, empty/oversize/non-ZIP
+            "artifact_superseded",           // 409 — finalize lost the compare-and-set
+            "artifact_storage_unconfigured", // 503 — both artifact legs, no store wired
+            "invoke_target_invalid",         // 422 — deploy
+            "status_invalid",                // 422 — deploy
+            "conflict",                      // 409 — deploy, artifact not ready
+            "internal_error",                // 500 — all three
+        ] {
+            assert!(!deploy_error_hint(code).is_empty(), "no hint for `{code}`");
+        }
     }
 
     #[test]

--- a/src/commands/module/mod.rs
+++ b/src/commands/module/mod.rs
@@ -525,7 +525,25 @@ fn deploy(args: DeployArgs) -> Result<()> {
     // `_artifact_dir` (the temp dir backing `zip_path`) stays alive across
     // this call by still being in scope — dropping it earlier would delete
     // the archive out from under the upload.
-    artifact::ship_artifact(
+    //
+    // `artifact_storage_unconfigured` is a WARN, not a failure. Two reasons:
+    //
+    //   1. It describes environments the platform deliberately keeps working.
+    //      api-platform#440's own deploy gate is conditional, and its comment
+    //      says so: "Local prod-sim and today's bucket-less production still
+    //      deploy without an upload, so an unconditional gate would brick
+    //      both." Local prod-sim has no bucket BY DESIGN — this is permanent
+    //      there, not a rollout-ordering artifact that disappears once prod
+    //      gets its bucket. Failing here would make `module deploy`
+    //      unusable locally.
+    //   2. `ensure_version_recorded` above has ALREADY frozen an immutable
+    //      module_versions row by the time the upload runs. Aborting here
+    //      strands that row: the version exists, nothing is deployed, and a
+    //      re-run just 409-skips the record and fails the same way.
+    //
+    // Every other artifact error stays fatal — `ship_artifact` only collapses
+    // this one code.
+    let shipped = artifact::ship_artifact(
         &client,
         &apps_base,
         &creds.access_token,
@@ -533,12 +551,25 @@ fn deploy(args: DeployArgs) -> Result<()> {
         &version,
         &zip_path,
     )?;
-    eprintln!(
-        "{} uploaded {} ({})",
-        ok_mark(),
-        style(format!("{slug}@{version}")).cyan().bold(),
-        artifact::human_bytes(artifact_size)
-    );
+    match shipped {
+        artifact::ShipOutcome::Shipped => eprintln!(
+            "{} uploaded {} ({})",
+            ok_mark(),
+            style(format!("{slug}@{version}")).cyan().bold(),
+            artifact::human_bytes(artifact_size)
+        ),
+        artifact::ShipOutcome::StorageUnconfigured => {
+            eprintln!(
+                "{} no artifact was uploaded for {}: this platform is not configured for module artifact storage.",
+                warn_prefix(),
+                style(format!("{slug}@{version}")).cyan().bold(),
+            );
+            eprintln!(
+                "  {} the version was recorded and the deploy continues, but it is not artifact-backed — the module runs from whatever transport this environment already resolves (local prod-sim, or an existing production function).",
+                style("note:").dim(),
+            );
+        }
+    }
 
     let result = with_spinner("Deploying…", || {
         api::set_module_deploy(
@@ -841,11 +872,25 @@ fn deploy_error_hint(code: &str) -> &'static str {
         "artifact_missing" => {
             " (the upload didn't land in object storage — re-run `mirrorstack module deploy`)"
         }
+        // The platform's finalize check is a non-empty object under its size
+        // ceiling whose first four bytes are the ZIP local-file magic — it
+        // does NOT open the archive, so don't claim it verified a `bootstrap`
+        // entry. (The CLI is what guarantees the executable root entry, in
+        // `artifact::zip_bootstrap`.)
         "artifact_invalid" => {
-            " (the platform rejected the uploaded zip — it must contain an executable `bootstrap` at the archive root and stay under 250.0 MB)"
+            " (the platform rejected the uploaded object — it must be a non-empty ZIP under 250.0 MB)"
         }
+        // Not reachable from the deploy call itself: the deploy gate is
+        // conditional on the platform having an artifact store, and the
+        // upload step already downgrades this code to a warning. Kept so the
+        // code never surfaces bare if another leg starts returning it.
         "artifact_storage_unconfigured" => {
-            " (module artifact storage is not configured on the platform — this is a platform-side issue, not something to fix locally)"
+            " (module artifact storage is not configured on the platform — expected for local prod-sim and bucket-less environments, not something to fix locally)"
+        }
+        // What `httputil.Conflict` emits when a deploy is attempted for a
+        // version whose artifact never finalized.
+        "conflict" => {
+            " (the artifact for this version isn't finalized — re-run `mirrorstack module deploy` so the upload completes before the deploy)"
         }
         _ => "",
     }
@@ -1166,8 +1211,13 @@ mod tests {
         assert!(deploy_error_hint("invoke_target_invalid").contains("platform"));
         assert!(deploy_error_hint("status_invalid").contains("--status"));
         assert!(deploy_error_hint("artifact_missing").contains("module deploy"));
-        assert!(deploy_error_hint("artifact_invalid").contains("bootstrap"));
+        // The platform only checks the ZIP magic and the size, so the hint
+        // must not claim it inspected the archive for a `bootstrap` entry.
+        let invalid = deploy_error_hint("artifact_invalid");
+        assert!(invalid.contains("ZIP"), "{invalid}");
+        assert!(!invalid.contains("bootstrap"), "{invalid}");
         assert!(deploy_error_hint("artifact_storage_unconfigured").contains("platform"));
+        assert!(deploy_error_hint("conflict").contains("finalized"));
         assert_eq!(deploy_error_hint("something_else"), "");
     }
 


### PR DESCRIPTION
## Why

`mirrorstack module deploy` recorded a version and upserted a `module_deploys` row while shipping **zero bytes of module code**. A "deployed" module could therefore only ever serve traffic through the developer's live `mirrorstack dev` tunnel — blocker C on the tracker.

Part of mirrorstack-ai/mirrorstack-core-v2#338 (build step 5).

## ⚠️ Land order — this must merge AFTER its api-platform counterpart

The endpoints this calls are **step 4 of #338 and do not exist on `api-platform` `main` yet**. Merging this first ships a CLI whose `module deploy` 404s at the upload step. Hold it until the api-platform PR lands.

The contract below was **reconciled against the in-flight api-platform branch** (`feat/module-artifact`: `handler/module_artifacts.go`, `service/module_artifacts.go`, the routes in `cmd/applications/main.go`), not invented. That branch was still uncommitted WIP when this was written, so re-check it once its PR opens:

```
POST /v1/modules/{moduleID}/versions/{versionRef}/artifact            # no body
  200 {"version_id","module_id","key","url","headers":{…},"expires_at"}

PUT <url>                                    # presigned; the signature IS the auth
  headers: replayed verbatim from the response above
  body:    the zip verbatim

POST /v1/modules/{moduleID}/versions/{versionRef}/artifact/finalize   # no body
  200 {"version_id","module_id","key","status","size_bytes","created_at","updated_at"}
```

Both calls are deliberately bodiless: the platform owns the object key outright and HEADs the uploaded object for size and digest at finalize, so the CLI declares nothing and echoes nothing back — there is no caller-supplied value to spoof. `versionRef` is the canonical SemVer string, path-safe verbatim, the same value `set_module_deploy` already takes. Error codes wired into the hint table are the platform's real ones: `artifact_missing`, `artifact_invalid`, `artifact_storage_unconfigured`.

## What changed

New `src/commands/module/artifact.rs` — the role `app/ssr.rs` plays for apps:

- **Cross-compile.** `GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o <tmp>/bootstrap .` in the module dir. The three vars are set **explicitly, not inherited**, so a shell or CI image that already exports `GOARCH=amd64` still produces a Graviton binary rather than one that only fails at cold start, in prod. A missing toolchain and a failed compile each get their own message; the compiler output is passed through verbatim.
- **arm64 is enforced, not assumed.** The produced file is checked to be a 64-bit little-endian AArch64 ELF (magic, `EI_CLASS` 2, `EI_DATA` 1, `e_machine` 183) before it is packaged. Every MirrorStack Lambda is Graviton and the native-binary guards assert `aarch64`.
- **`provided.al2023` packaging.** One entry named exactly `bootstrap`, at the archive **root**, with unix mode `0o755`. Both details are the classic silent failure: a directory prefix and the function never starts; a `0644` entry dies at init with a permission error.
- **Size guard** against Lambda's 250 MB S3-sourced deployment-package ceiling, with the limit named in the error, checked before any bytes move.
- **create-upload → PUT → finalize**, mirroring `app/deploy.rs`: a separate bearer-free upload client on a 300 s timeout, the server-supplied headers replayed verbatim, `.without_url()` on the reqwest error so a live write signature can never reach a CI log, and `http::read_capped` for a non-2xx body.

Wired into `fn deploy` so the order is: resolve version → `-dev` promote prompt → **build + zip + size-check** → `ensure_version_recorded` → **create-upload/PUT/finalize** → `set_module_deploy`.

The local steps run **before** the version record on purpose: a compile error or an oversize bundle then fails without first freezing an immutable record. Same posture `deploy_ssr_with_cap` takes — package and size-check before `create_app_deploy`.

`ensure_version_recorded` and the tunnel/publish path are **untouched** (that is step 8, a separate PR).

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --no-fail-fast` (**307 passed**, up from 302 on `main` — 5 added, none removed), `cargo build --release --locked`: all clean. The previous revision of this branch was green on all 8 CI checks including Windows.
- New tests cover the zip shape (single root `bootstrap` entry at `0755`), the AArch64 guard (accepts `e_machine` 183, rejects x86-64 and non-ELF), the size guard tripping before any network call, and a full create-upload → PUT → finalize round trip (mockito for the two JSON calls + a raw `TcpListener` capture stub for the presigned PUT, the pattern `app/deploy.rs` already uses). The round trip asserts the uploaded bytes really are a zip containing `bootstrap`, that the server's `Content-Type` header was replayed, and that **no `Authorization` header follows the presigned URL**. None need Go or a network.
- **Proved against the real toolchain locally** (throwaway probe, not committed — CI must not need Go): `build_bootstrap` on a real Go module produced `ELF 64-bit LSB executable, ARM aarch64, statically linked`, mode `0755`, zipped to a 1.3 MB archive with one root `bootstrap` entry at `0755`. Re-running with `GOARCH=amd64 GOOS=linux CGO_ENABLED=1` exported in the parent environment produced a byte-identical result, confirming the explicit env override does its job.

## Out of scope, reported not fixed

The recon flagged UI/CLI command drift in **web-applications**; per the brief it is reported here, not edited. On `web-applications` `origin/main`:

- `src/app/apps/[appId]/(tabbed)/settings/deployment/page.tsx:299` → `mirrorstack app web deploy --app <slug> --env <env>`
- `src/components/deploy-credentials-section.tsx:116` → `mirrorstack apps web deploy --app <slug> --dir out --oidc`

Confirmed from source (`src/commands/mod.rs`, `src/commands/app/mod.rs`, `src/commands/app/deploy.rs`): the real subcommand is **`mirrorstack apps web deploy`**, and `app` is a registered `visible_alias` for `apps`, so both spellings execute. The substantive defect is not the alias — it is that the `page.tsx` string **omits `--dir`**, which defaults to the current directory. A user who copies it from their repo root uploads (or fails on) the working tree instead of the build output. Canonical form:

```
mirrorstack apps web deploy --app <slug> --env <env> --dir <build-dir>
```

Both strings should be normalized to `apps` and both should carry `--dir`, in a `web-applications` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)