### PR TITLE
feat(module): move an installed module between published versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ mirrorstack app web deploy     # Deploy a static build directory to app hosting
 mirrorstack module capabilities         # Which host slots exist, who fills them, what is broken
 mirrorstack module capabilities --json  # …the same index, machine-readable
 mirrorstack module capabilities --app @me/my-app  # …resolved against the app's installed versions
+mirrorstack module move --app my-app --module media             # Pick a published version to move that install onto
+mirrorstack module move --app my-app --module media --to 0.2.0  # …or name it outright
 mirrorstack --help             # Show help
 mirrorstack --version          # Show CLI version
 ```

--- a/src/api.rs
+++ b/src/api.rs
@@ -3043,7 +3043,12 @@ mod tests {
             .mock("POST", "/v1/apps/app-1/modules/mod-uuid/update")
             .with_status(422)
             .with_body(
-                r#"{"error":{"code":"downgrade_not_supported","message":"target version must be newer than the installed version"}}"#,
+                // Verbatim from api-platform#442's handler for the
+                // semver-backward refusal, which is what a request that did
+                // NOT opt in gets back. The retired "target version must be
+                // newer than the installed version" no longer exists there:
+                // #442 made backward moves opt-in rather than impossible.
+                r#"{"error":{"code":"downgrade_not_supported","message":"target version is older than the installed version; re-send with \"allowDowngrade\": true to accept the app-scope migration rollback and the data it destroys"}}"#,
             )
             .create();
 
@@ -3055,7 +3060,7 @@ mod tests {
             "mod-uuid",
             &UpdateInstallInput {
                 version: "0.1.0",
-                allow_downgrade: true,
+                allow_downgrade: false,
             },
         )
         .unwrap_err();

--- a/src/api.rs
+++ b/src/api.rs
@@ -648,6 +648,177 @@ pub fn list_app_installs(
     Err(unexpected_body_error(resp))
 }
 
+/// One published version of a module, as returned by
+/// `GET /v1/modules/{moduleId}/version-history`. The changelog map the
+/// platform also returns is deliberately not modelled — the CLI lists
+/// versions to pick from, it doesn't render release notes.
+#[derive(Debug, Deserialize)]
+pub struct PublishedVersion {
+    pub version: String,
+    #[serde(default)]
+    pub published_at: String,
+}
+
+#[derive(Deserialize)]
+struct PublishedVersionList {
+    versions: Vec<PublishedVersion>,
+}
+
+/// GET /v1/modules/{moduleId}/version-history — every published (non-yanked)
+/// version of a module, newest first.
+///
+/// This is the any-authenticated-user sibling of [`list_module_versions`]:
+/// that one is OWNER-scoped (404 for an app admin who merely installed the
+/// module), this one deliberately is not, so an operator can enumerate the
+/// versions of somebody else's module before moving an install onto one.
+/// A module with no published versions yields an empty list, not a 404.
+pub fn list_module_version_history(
+    http: &Client,
+    apps_base: &str,
+    access_token: &str,
+    module_id: &str,
+) -> Result<Vec<PublishedVersion>, ApiError> {
+    let endpoint = format!(
+        "{}/v1/modules/{}/version-history",
+        apps_base.trim_end_matches('/'),
+        module_id
+    );
+
+    let resp = http
+        .get(&endpoint)
+        .bearer_auth(access_token)
+        .header("Accept", "application/json")
+        .send()?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp.json::<PublishedVersionList>()?.versions);
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(ApiError::Unauthenticated);
+    }
+    Err(unexpected_body_error(resp))
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdateInstallInput<'a> {
+    /// Canonical SemVer of the target published version, no `v` prefix.
+    pub version: &'a str,
+    /// Explicit opt-in to moving BACKWARDS to an older version. Skipped
+    /// entirely when false so a platform that predates the field receives
+    /// byte-for-byte the body it has always received. camelCase to match the
+    /// install family's request bodies (`moduleId`, `routeLocal`).
+    #[serde(rename = "allowDowngrade", skip_serializing_if = "is_false")]
+    pub allow_downgrade: bool,
+}
+
+/// `skip_serializing_if` predicate for [`UpdateInstallInput::allow_downgrade`].
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// One peer install whose pinned dependency constraint rejects the target
+/// version, carried on the 409 `update_held` envelope.
+#[derive(Debug, Deserialize)]
+pub struct UpdateBlocker {
+    /// The peer module's slug.
+    pub module: String,
+    /// The peer's published version constraint on the module being moved.
+    pub constraint: String,
+}
+
+/// The two outcomes of a version move that are both *answers*, not failures.
+/// `update_held` is modelled as a value rather than an [`ApiError`] for the
+/// same reason [`get_module`] returns `Option`: the platform is telling the
+/// caller something specific about their request, and the blocker list has
+/// to survive the trip. Keeping the error type as `ApiError` also lets the
+/// call sit inside `credentials::with_refresh_retry` unchanged.
+#[derive(Debug)]
+pub enum UpdateOutcome {
+    Updated(Box<AppInstall>),
+    Held(Vec<UpdateBlocker>),
+}
+
+/// Error envelope for the update endpoint. A superset of [`ErrorEnvelope`]:
+/// `update_held` adds the blocker list alongside code/message.
+#[derive(Deserialize)]
+struct UpdateErrorEnvelope {
+    error: UpdateErrorBody,
+}
+#[derive(Deserialize)]
+struct UpdateErrorBody {
+    code: String,
+    message: String,
+    #[serde(default)]
+    blockers: Vec<UpdateBlocker>,
+}
+
+/// POST /v1/apps/{appRef}/modules/{moduleId}/update — move an installed
+/// module's version pin to another published version of that module.
+/// `app_ref` is an app id or slug (the platform resolves either);
+/// `module_id` is the raw platform UUID, not the sanitized `m<hex>` form.
+///
+/// Owner/admin gated and membership-scoped: a non-member sees the same 404
+/// as a missing app. The platform re-checks every peer install's dependency
+/// constraint authoritatively and runs the module's app-scope migrations
+/// before repinning, so this call can take a while and a failure leaves the
+/// install on its old version.
+pub fn update_install_version(
+    http: &Client,
+    apps_base: &str,
+    access_token: &str,
+    app_ref: &str,
+    module_id: &str,
+    input: &UpdateInstallInput,
+) -> Result<UpdateOutcome, ApiError> {
+    let endpoint = format!(
+        "{}/v1/apps/{}/modules/{}/update",
+        apps_base.trim_end_matches('/'),
+        app_ref,
+        module_id
+    );
+
+    let resp = http
+        .post(&endpoint)
+        .bearer_auth(access_token)
+        .header("Accept", "application/json")
+        .json(input)
+        .send()?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(UpdateOutcome::Updated(Box::new(resp.json::<AppInstall>()?)));
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(ApiError::Unauthenticated);
+    }
+
+    let status_u16 = status.as_u16();
+    let body = match http::read_capped(resp) {
+        Ok(b) => b,
+        Err(e) => {
+            return Err(ApiError::Unexpected {
+                status: status_u16,
+                body: format!("(read body failed: {e})"),
+            });
+        }
+    };
+    if let Ok(env) = serde_json::from_slice::<UpdateErrorEnvelope>(&body) {
+        if env.error.code == "update_held" {
+            return Ok(UpdateOutcome::Held(env.error.blockers));
+        }
+        return Err(ApiError::Server {
+            status: status_u16,
+            code: env.error.code,
+            message: env.error.message,
+        });
+    }
+    Err(ApiError::Unexpected {
+        status: status_u16,
+        body: String::from_utf8_lossy(&body).into_owned(),
+    })
+}
+
 /// One file of an app deploy's manifest, as POSTed to the platform.
 #[derive(Debug, Serialize)]
 pub struct DeployFile<'a> {
@@ -2720,5 +2891,205 @@ mod tests {
             }
             other => panic!("expected Unexpected, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn list_module_version_history_returns_versions_newest_first() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("GET", "/v1/modules/mod-uuid/version-history")
+            .match_header("authorization", "Bearer AT")
+            .with_status(200)
+            .with_body(
+                json!({"versions": [
+                    {"version": "0.2.0", "changelog": {"default": "notes"}, "published_at": "2026-07-30T00:00:00Z"},
+                    {"version": "0.1.0", "changelog": {}, "published_at": "2026-07-01T00:00:00Z"}
+                ]})
+                .to_string(),
+            )
+            .create();
+
+        let versions =
+            list_module_version_history(&test_client(), &server.url(), "AT", "mod-uuid").unwrap();
+        assert_eq!(versions.len(), 2);
+        assert_eq!(versions[0].version, "0.2.0");
+        assert_eq!(versions[0].published_at, "2026-07-30T00:00:00Z");
+    }
+
+    #[test]
+    fn list_module_version_history_empty_for_versionless_module() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("GET", "/v1/modules/mod-uuid/version-history")
+            .with_status(200)
+            .with_body(r#"{"versions":[]}"#)
+            .create();
+
+        let versions =
+            list_module_version_history(&test_client(), &server.url(), "AT", "mod-uuid").unwrap();
+        assert!(versions.is_empty());
+    }
+
+    #[test]
+    fn update_install_version_omits_allow_downgrade_when_false() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/apps/app-1/modules/mod-uuid/update")
+            .match_header("authorization", "Bearer AT")
+            // A platform that predates opt-in downgrades must see exactly the
+            // body it has always seen.
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"version":"0.2.0"}"#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({"moduleId": "mod-uuid", "slug": "media", "installedVersion": "0.2.0"})
+                    .to_string(),
+            )
+            .create();
+
+        let outcome = update_install_version(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "app-1",
+            "mod-uuid",
+            &UpdateInstallInput {
+                version: "0.2.0",
+                allow_downgrade: false,
+            },
+        )
+        .expect("ok");
+        match outcome {
+            UpdateOutcome::Updated(install) => {
+                assert_eq!(install.installed_version, "0.2.0");
+                assert_eq!(install.slug, "media");
+            }
+            other => panic!("expected Updated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_install_version_sends_allow_downgrade_when_set() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/apps/app-1/modules/mod-uuid/update")
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"version":"0.1.0","allowDowngrade":true}"#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({"moduleId": "mod-uuid", "slug": "media", "installedVersion": "0.1.0"})
+                    .to_string(),
+            )
+            .create();
+
+        update_install_version(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "app-1",
+            "mod-uuid",
+            &UpdateInstallInput {
+                version: "0.1.0",
+                allow_downgrade: true,
+            },
+        )
+        .expect("ok");
+    }
+
+    #[test]
+    fn update_install_version_409_held_carries_blockers() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/apps/app-1/modules/mod-uuid/update")
+            .with_status(409)
+            .with_body(
+                json!({"error": {
+                    "code": "update_held",
+                    "message": "update held by installed peer dependency constraints",
+                    "blockers": [{"module": "oauth-google", "constraint": "^0.1"}]
+                }})
+                .to_string(),
+            )
+            .create();
+
+        let outcome = update_install_version(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "app-1",
+            "mod-uuid",
+            &UpdateInstallInput {
+                version: "0.2.0",
+                allow_downgrade: false,
+            },
+        )
+        .expect("held is an outcome, not an error");
+        match outcome {
+            UpdateOutcome::Held(blockers) => {
+                assert_eq!(blockers.len(), 1);
+                assert_eq!(blockers[0].module, "oauth-google");
+                assert_eq!(blockers[0].constraint, "^0.1");
+            }
+            other => panic!("expected Held, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_install_version_422_surfaces_downgrade_code() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/apps/app-1/modules/mod-uuid/update")
+            .with_status(422)
+            .with_body(
+                r#"{"error":{"code":"downgrade_not_supported","message":"target version must be newer than the installed version"}}"#,
+            )
+            .create();
+
+        let err = update_install_version(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "app-1",
+            "mod-uuid",
+            &UpdateInstallInput {
+                version: "0.1.0",
+                allow_downgrade: true,
+            },
+        )
+        .unwrap_err();
+        match err {
+            ApiError::Server { status, code, .. } => {
+                assert_eq!(status, 422);
+                assert_eq!(code, "downgrade_not_supported");
+            }
+            other => panic!("expected Server, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_install_version_401_is_unauthenticated() {
+        let mut server = Server::new();
+        let _m = server
+            .mock("POST", "/v1/apps/app-1/modules/mod-uuid/update")
+            .with_status(401)
+            .with_body(r#"{"error":{"code":"token_expired","message":"expired"}}"#)
+            .create();
+
+        assert!(matches!(
+            update_install_version(
+                &test_client(),
+                &server.url(),
+                "bad",
+                "app-1",
+                "mod-uuid",
+                &UpdateInstallInput {
+                    version: "0.2.0",
+                    allow_downgrade: false,
+                },
+            ),
+            Err(ApiError::Unauthenticated)
+        ));
     }
 }

--- a/src/commands/module/mod.rs
+++ b/src/commands/module/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod capabilities;
 mod changelog;
 mod readme;
 mod scaffold;
+mod version_move;
 
 use super::{
     DEFAULT_API_BASE, DEFAULT_APPS_API_BASE, DEFAULT_DISPATCH_BASE, DEFAULT_WEB_BASE, ENV_API_URL,
@@ -56,6 +57,10 @@ enum ModuleCommand {
     /// key to ship a new entry. The prod transport target is derived by the
     /// platform from the module's own identity, never supplied by the caller.
     Deploy(DeployArgs),
+    /// Move one app's installed module onto another published version of
+    /// that module. Forward by default; moving backwards needs an explicit
+    /// --allow-downgrade. Omit --to to pick from the published versions.
+    Move(version_move::MoveArgs),
 }
 
 #[derive(Args)]
@@ -118,6 +123,7 @@ pub fn run(args: ModuleArgs) -> Result<()> {
         ModuleCommand::Init(i) => init(i),
         ModuleCommand::Register(r) => register(r),
         ModuleCommand::Deploy(d) => deploy(d),
+        ModuleCommand::Move(m) => version_move::run(m),
     }
 }
 

--- a/src/commands/module/version_move.rs
+++ b/src/commands/module/version_move.rs
@@ -1,0 +1,513 @@
+//! `mirrorstack module move` — move one app's installed module from the
+//! version it is pinned to onto another published version of that module.
+//!
+//! This is the operator side of per-version module transport: an install
+//! points at exactly one published version, and rolling forward (or, with
+//! `--allow-downgrade`, back) is a deliberate act on ONE app's install, not
+//! a platform-wide flip. The platform re-checks peer dependency constraints
+//! and runs the module's app-scope migrations before repinning, so the
+//! command is a thin, honest client: resolve → confirm → POST → explain.
+
+use std::io::IsTerminal;
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use clap::Args;
+use console::style;
+use dialoguer::{Confirm, Select, theme::ColorfulTheme};
+
+use crate::api::{self, ApiError, AppInstall, PublishedVersion, UpdateInstallInput, UpdateOutcome};
+use crate::commands::dev::module_meta;
+use crate::credentials;
+use crate::http;
+
+use super::with_spinner;
+use crate::commands::{
+    DEFAULT_APPS_API_BASE, ENV_APPS_API_URL, ok_mark, resolve_base, session_expired, warn_prefix,
+};
+
+/// The platform's placeholder for an install with no version pin (a module
+/// mounted straight off a dev tunnel). Such an install has nothing to
+/// compare a target against, so the downgrade gate can't apply to it.
+const DEV_INSTALL: &str = "dev";
+
+/// The move runs the module's app-scope migrations server-side before the
+/// pin is written, so it is not a fast request — a 15s timeout (what the
+/// other module commands use) would abort a legitimately slow upgrade and
+/// leave the operator unsure whether it landed.
+const MOVE_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[derive(Args)]
+pub struct MoveArgs {
+    /// App whose install is being moved (id or slug).
+    #[arg(long)]
+    app: String,
+    /// Installed module to move — its slug, or its platform UUID when two
+    /// installed modules share a slug.
+    #[arg(long)]
+    module: String,
+    /// Target published version (canonical SemVer, e.g. 0.2.0). When
+    /// omitted, the module's published versions are listed to pick from.
+    #[arg(long)]
+    to: Option<String>,
+    /// Move BACKWARDS to a version that is not newer than the installed one.
+    /// Off by default: module migrations are forward-only, so an older
+    /// version may not understand data the newer one already wrote.
+    #[arg(long)]
+    allow_downgrade: bool,
+    /// Skip the confirmation prompt.
+    #[arg(long, short)]
+    yes: bool,
+}
+
+pub(super) fn run(args: MoveArgs) -> Result<()> {
+    let mut creds = credentials::load_or_login_hint()?;
+    let apps_base = resolve_base(ENV_APPS_API_URL, DEFAULT_APPS_API_BASE);
+    let client = http::client(MOVE_TIMEOUT)?;
+
+    // `list_app_installs` resolves the per-app tenant schema from the id, so
+    // it needs the UUID — the id-or-slug `--app` is resolved first. The
+    // update endpoint itself takes either, but it is given the same
+    // canonical id so all three calls talk about one resolved app.
+    let app = match credentials::with_refresh_retry(&mut creds, |tok| {
+        api::get_app(&client, &apps_base, tok, &args.app)
+    }) {
+        Ok(Some(app)) => app,
+        Ok(None) => {
+            return Err(anyhow!(
+                "app '{}' not found (or you are not a member)",
+                args.app
+            ));
+        }
+        Err(ApiError::Unauthenticated) => return Err(session_expired()),
+        Err(e) => return Err(e.into()),
+    };
+
+    let installs = match credentials::with_refresh_retry(&mut creds, |tok| {
+        api::list_app_installs(&client, &apps_base, tok, &app.id)
+    }) {
+        Ok(installs) => installs,
+        Err(ApiError::Unauthenticated) => return Err(session_expired()),
+        Err(e) => return Err(e.into()),
+    };
+    let install = find_install(&installs, &args.module, &app.slug)?;
+
+    let published = match credentials::with_refresh_retry(&mut creds, |tok| {
+        api::list_module_version_history(&client, &apps_base, tok, &install.module_id)
+    }) {
+        Ok(versions) => versions,
+        Err(ApiError::Unauthenticated) => return Err(session_expired()),
+        Err(e) => return Err(e.into()),
+    };
+    if published.is_empty() {
+        return Err(anyhow!(
+            "{} has no published versions to move to — its author has to run `mirrorstack app module deploy` first",
+            install.slug
+        ));
+    }
+
+    let target = match args.to.as_deref() {
+        Some(requested) => resolve_requested(requested, &published)?,
+        None => choose_version(&published, &install.installed_version)?,
+    };
+
+    if target == install.installed_version {
+        eprintln!(
+            "{} {} is already at {} in {} — nothing to move.",
+            ok_mark(),
+            style(&install.slug).cyan().bold(),
+            style(&target).bold(),
+            style(&app.slug).cyan()
+        );
+        return Ok(());
+    }
+
+    // Client-side downgrade gate. Advisory — the platform decides — but it
+    // is what makes `--allow-downgrade` a real opt-in instead of a flag that
+    // only matters once the request has already been sent.
+    let backwards = is_backwards(&install.installed_version, &target);
+    if backwards && !args.allow_downgrade {
+        return Err(anyhow!(
+            "{} is installed at {} in {}; {} is not newer. Pass --allow-downgrade to move backwards — module migrations are forward-only, so an older version may not understand data the newer one already wrote.",
+            install.slug,
+            install.installed_version,
+            app.slug,
+            target
+        ));
+    }
+
+    if !args.yes {
+        eprintln!();
+        eprintln!("  {}    {}", style("App:").dim(), style(&app.slug).bold());
+        eprintln!(
+            "  {} {}",
+            style("Module:").dim(),
+            style(&install.slug).cyan().bold()
+        );
+        eprintln!(
+            "  {}   {} → {}",
+            style("Move:").dim(),
+            style(&install.installed_version).dim(),
+            style(&target).bold()
+        );
+        if backwards {
+            eprintln!(
+                "{} this is a DOWNGRADE. The module's app migrations only run forward, so {} may not be able to read data {} wrote.",
+                warn_prefix(),
+                target,
+                install.installed_version
+            );
+        }
+        let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(format!("Move {} to {target}?", install.slug))
+            .default(!backwards)
+            .interact()?;
+        if !confirmed {
+            eprintln!("{}", style("aborted.").yellow());
+            return Ok(());
+        }
+    }
+
+    let result = with_spinner("Moving…", || {
+        credentials::with_refresh_retry(&mut creds, |tok| {
+            api::update_install_version(
+                &client,
+                &apps_base,
+                tok,
+                &app.id,
+                &install.module_id,
+                &UpdateInstallInput {
+                    version: &target,
+                    allow_downgrade: args.allow_downgrade,
+                },
+            )
+        })
+    });
+
+    match result {
+        Ok(UpdateOutcome::Updated(updated)) => {
+            eprintln!(
+                "{} moved {} {} → {}",
+                ok_mark(),
+                style(&install.slug).cyan().bold(),
+                style(&install.installed_version).dim(),
+                style(&updated.installed_version).bold()
+            );
+            eprintln!("  {} {}", style("app:").dim(), app.slug);
+            Ok(())
+        }
+        Ok(UpdateOutcome::Held(blockers)) => Err(held_error(&install.slug, &target, &blockers)),
+        Err(ApiError::Server { code, message, .. }) => Err(anyhow!(
+            "{code}: {message}{hint}",
+            hint = move_error_hint(&code, args.allow_downgrade)
+        )),
+        Err(ApiError::Unauthenticated) => Err(session_expired()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Locate the install `--module` names. Matching on the module slug is the
+/// ergonomic case; the platform UUID is accepted too because two installed
+/// modules from different owners can legitimately share a slug, and then the
+/// slug alone is not an answer.
+fn find_install<'a>(
+    installs: &'a [AppInstall],
+    module: &str,
+    app_slug: &str,
+) -> Result<&'a AppInstall> {
+    if let Some(exact) = installs.iter().find(|i| i.module_id == module) {
+        return Ok(exact);
+    }
+    let matches: Vec<&AppInstall> = installs.iter().filter(|i| i.slug == module).collect();
+    match matches.as_slice() {
+        [only] => Ok(only),
+        [] => Err(anyhow!(
+            "'{module}' is not installed in {app_slug}{installed}",
+            installed = installed_list(installs)
+        )),
+        many => Err(anyhow!(
+            "{n} installed modules use the slug '{module}' in {app_slug} — pass --module with the platform UUID instead ({ids})",
+            n = many.len(),
+            ids = many
+                .iter()
+                .map(|i| i.module_id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
+fn installed_list(installs: &[AppInstall]) -> String {
+    if installs.is_empty() {
+        return " (no modules are installed in it)".into();
+    }
+    format!(
+        " (installed: {})",
+        installs
+            .iter()
+            .map(|i| i.slug.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+/// Check an explicit `--to` against what the module actually publishes, so a
+/// typo is a local error listing the real choices rather than a bare 404.
+/// The `v` prefix the SDK uses for its `Config.Versions` keys is tolerated —
+/// the wire form is canonical SemVer without it.
+fn resolve_requested(requested: &str, published: &[PublishedVersion]) -> Result<String> {
+    let wanted = requested.strip_prefix('v').unwrap_or(requested);
+    if published.iter().any(|v| v.version == wanted) {
+        return Ok(wanted.to_string());
+    }
+    Err(anyhow!(
+        "{requested} is not a published version of this module. Published: {}",
+        published
+            .iter()
+            .map(|v| v.version.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+}
+
+/// Pick a target when `--to` was omitted. On a TTY that is a prompt over the
+/// published versions (newest first, the installed one marked); without one
+/// the same list is printed and the command stops — guessing a version on
+/// the operator's behalf is not something a non-interactive run should do.
+fn choose_version(published: &[PublishedVersion], installed: &str) -> Result<String> {
+    let labels: Vec<String> = published
+        .iter()
+        .map(|v| version_label(v, installed))
+        .collect();
+
+    if !std::io::stderr().is_terminal() {
+        eprintln!("{}", style("Published versions:").bold());
+        for label in &labels {
+            eprintln!("  {label}");
+        }
+        return Err(anyhow!(
+            "pass --to <version> to choose one (no terminal to prompt on)"
+        ));
+    }
+
+    let picked = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Move to which version?")
+        .items(&labels)
+        .default(0)
+        .interact()?;
+    Ok(published[picked].version.clone())
+}
+
+fn version_label(v: &PublishedVersion, installed: &str) -> String {
+    let mut label = v.version.clone();
+    // RFC3339 from the platform; the date alone is what an operator scans.
+    if let Some(date) = v.published_at.get(..10) {
+        label.push_str(&format!("  ({date})"));
+    }
+    if v.version == installed {
+        label.push_str("  ← installed");
+    }
+    label
+}
+
+/// Whether `target` is NOT strictly newer than `installed` — the condition
+/// `--allow-downgrade` exists for. A dev-mount install (no pin) and any
+/// version either side can't parse as SemVer are left to the platform,
+/// which is the authority; guessing here would block a legal move.
+fn is_backwards(installed: &str, target: &str) -> bool {
+    if installed == DEV_INSTALL {
+        return false;
+    }
+    match (
+        module_meta::parse_semver(installed),
+        module_meta::parse_semver(target),
+    ) {
+        (Some(from), Some(to)) => to <= from,
+        _ => false,
+    }
+}
+
+fn held_error(slug: &str, target: &str, blockers: &[api::UpdateBlocker]) -> anyhow::Error {
+    let detail = blockers
+        .iter()
+        .map(|b| format!("{} needs {}", b.module, b.constraint))
+        .collect::<Vec<_>>()
+        .join(", ");
+    anyhow!(
+        "update_held: {slug}@{target} is rejected by {n} installed peer module(s) — {detail}. Move or uninstall the blocking peer(s) first, or pick a version their constraints allow.",
+        n = blockers.len()
+    )
+}
+
+/// Hints for the codes `POST /v1/apps/{ref}/modules/{id}/update` returns.
+/// `update_held` never reaches here — its 409 carries a blocker list and is
+/// surfaced by [`held_error`] instead.
+///
+/// `downgrade_not_supported` is the version-skew case: a platform that
+/// predates opt-in downgrades ignores the `allowDowngrade` field (its
+/// decoder drops unknown keys) and still refuses, so a caller who DID pass
+/// the flag is told the server is old rather than being told to pass a flag
+/// they already passed.
+fn move_error_hint(code: &str, allow_downgrade: bool) -> &'static str {
+    match code {
+        "version_not_found" => {
+            " (that version isn't published for this module any more — re-run without --to to list what is)"
+        }
+        "downgrade_not_supported" if allow_downgrade => {
+            " (this platform still refuses downgrades outright — it ignored --allow-downgrade. Update the platform, or pick a version newer than the installed one.)"
+        }
+        "downgrade_not_supported" => {
+            " (the target is not newer than the installed version — pass --allow-downgrade to move backwards)"
+        }
+        "not_found" => " (no such app, the module isn't installed in it, or you are not a member)",
+        "forbidden" => " (moving an install's version needs the app owner or an admin)",
+        "validation_error" | "bad_request" => {
+            " (the platform rejected the request body — versions must be canonical SemVer, e.g. 0.2.0)"
+        }
+        _ => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn install(module_id: &str, slug: &str, version: &str) -> AppInstall {
+        AppInstall {
+            module_id: module_id.into(),
+            name: slug.into(),
+            slug: slug.into(),
+            installed_version: version.into(),
+            manifest: None,
+            serving: "deployed".into(),
+        }
+    }
+
+    fn published(version: &str) -> PublishedVersion {
+        PublishedVersion {
+            version: version.into(),
+            published_at: "2026-07-30T10:11:12Z".into(),
+        }
+    }
+
+    #[test]
+    fn find_install_matches_slug() {
+        let installs = [
+            install("m1", "media", "0.1.0"),
+            install("m2", "auth", "1.0.0"),
+        ];
+        assert_eq!(
+            find_install(&installs, "auth", "app").unwrap().module_id,
+            "m2"
+        );
+    }
+
+    #[test]
+    fn find_install_matches_uuid() {
+        let installs = [install("m1", "media", "0.1.0")];
+        assert_eq!(find_install(&installs, "m1", "app").unwrap().slug, "media");
+    }
+
+    #[test]
+    fn find_install_lists_installed_on_miss() {
+        let installs = [install("m1", "media", "0.1.0")];
+        let err = find_install(&installs, "nope", "my-app")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("my-app"), "{err}");
+        assert!(err.contains("installed: media"), "{err}");
+    }
+
+    #[test]
+    fn find_install_refuses_ambiguous_slug() {
+        let installs = [
+            install("m1", "media", "0.1.0"),
+            install("m2", "media", "0.2.0"),
+        ];
+        let err = find_install(&installs, "media", "my-app")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--module with the platform UUID"), "{err}");
+        assert!(err.contains("m1, m2"), "{err}");
+    }
+
+    #[test]
+    fn resolve_requested_accepts_published_and_strips_v() {
+        let versions = [published("0.2.0"), published("0.1.0")];
+        assert_eq!(resolve_requested("0.2.0", &versions).unwrap(), "0.2.0");
+        assert_eq!(resolve_requested("v0.1.0", &versions).unwrap(), "0.1.0");
+    }
+
+    #[test]
+    fn resolve_requested_lists_choices_on_miss() {
+        let versions = [published("0.2.0"), published("0.1.0")];
+        let err = resolve_requested("9.9.9", &versions)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Published: 0.2.0, 0.1.0"), "{err}");
+    }
+
+    #[test]
+    fn is_backwards_detects_older_and_equal() {
+        assert!(is_backwards("0.2.0", "0.1.0"));
+        assert!(is_backwards("0.2.0", "0.2.0"));
+        assert!(is_backwards("1.0.0", "1.0.0-beta.1"));
+    }
+
+    #[test]
+    fn is_backwards_false_for_forward_and_dev() {
+        assert!(!is_backwards("0.1.0", "0.2.0"));
+        // A dev-mount install has no pin to compare against, so any published
+        // target is a forward move — the same rule the platform applies.
+        assert!(!is_backwards(DEV_INSTALL, "0.1.0"));
+        // Unparseable either side: defer to the platform rather than block.
+        assert!(!is_backwards("not-semver", "0.1.0"));
+    }
+
+    #[test]
+    fn version_label_marks_installed_and_dates() {
+        let label = version_label(&published("0.2.0"), "0.2.0");
+        assert!(label.contains("2026-07-30"), "{label}");
+        assert!(label.contains("← installed"), "{label}");
+        assert!(!version_label(&published("0.1.0"), "0.2.0").contains("installed"));
+    }
+
+    #[test]
+    fn held_error_names_every_blocker() {
+        let blockers = [
+            api::UpdateBlocker {
+                module: "oauth-google".into(),
+                constraint: "^0.1".into(),
+            },
+            api::UpdateBlocker {
+                module: "billing".into(),
+                constraint: "~0.1.2".into(),
+            },
+        ];
+        let err = held_error("media", "0.2.0", &blockers).to_string();
+        assert!(err.contains("oauth-google needs ^0.1"), "{err}");
+        assert!(err.contains("billing needs ~0.1.2"), "{err}");
+        assert!(err.contains("2 installed peer module(s)"), "{err}");
+    }
+
+    #[test]
+    fn move_error_hint_splits_on_the_downgrade_flag() {
+        assert!(
+            move_error_hint("downgrade_not_supported", false).contains("pass --allow-downgrade")
+        );
+        let old_server = move_error_hint("downgrade_not_supported", true);
+        assert!(
+            old_server.contains("ignored --allow-downgrade"),
+            "{old_server}"
+        );
+    }
+
+    #[test]
+    fn move_error_hint_for_other_known_codes() {
+        assert!(move_error_hint("version_not_found", false).contains("--to"));
+        assert!(move_error_hint("forbidden", false).contains("admin"));
+        assert!(move_error_hint("not_found", false).contains("member"));
+        assert!(move_error_hint("validation_error", false).contains("SemVer"));
+        assert_eq!(move_error_hint("something_else", false), "");
+    }
+}

--- a/src/commands/module/version_move.rs
+++ b/src/commands/module/version_move.rs
@@ -27,8 +27,14 @@ use crate::commands::{
 };
 
 /// The platform's placeholder for an install with no version pin (a module
-/// mounted straight off a dev tunnel). Such an install has nothing to
-/// compare a target against, so the downgrade gate can't apply to it.
+/// mounted straight off a dev tunnel). There is no installed version string,
+/// so the platform's SemVer comparison is skipped for these installs — but
+/// its downgrade gate is NOT. It then judges direction on the app-migration
+/// counters alone, and a target declaring FEWER app migrations than the
+/// install has already applied is refused with `downgrade_not_supported`
+/// unless the request opted in (api-platform#442,
+/// `service.ErrInstallMigrationRollback`). The CLI is never told those
+/// counters, which is why [`is_backwards`] leaves this case to the platform.
 const DEV_INSTALL: &str = "dev";
 
 /// The move runs the module's app-scope migrations server-side before the
@@ -489,8 +495,15 @@ mod tests {
         // Equal is version_unchanged on the platform, not a downgrade —
         // --allow-downgrade would not make it succeed, so don't demand it.
         assert!(!is_backwards("0.2.0", "0.2.0"));
-        // A dev-mount install has no pin to compare against, so any published
-        // target is a forward move — the same rule the platform applies.
+        // NOT because a dev-mount move is always forward — under
+        // api-platform#442 the counter gate applies to exactly these installs
+        // and can refuse one with `downgrade_not_supported`. It is because the
+        // CLI cannot tell: direction there is decided by the target's
+        // app-migration count against the install's watermark, and neither
+        // number is on `AppInstall`. Returning true would demand
+        // --allow-downgrade for every dev-mount move including the forward
+        // ones; false costs one round trip in the rare backward case, and the
+        // platform's refusal already names the flag.
         assert!(!is_backwards(DEV_INSTALL, "0.1.0"));
         // Unparseable either side: defer to the platform rather than block.
         assert!(!is_backwards("not-semver", "0.1.0"));

--- a/src/commands/module/version_move.rs
+++ b/src/commands/module/version_move.rs
@@ -50,9 +50,11 @@ pub struct MoveArgs {
     /// omitted, the module's published versions are listed to pick from.
     #[arg(long)]
     to: Option<String>,
-    /// Move BACKWARDS to a version that is not newer than the installed one.
-    /// Off by default: module migrations are forward-only, so an older
-    /// version may not understand data the newer one already wrote.
+    /// Move BACKWARDS to an older version. Off by default because the move
+    /// runs the module's app-scope migrations in REVERSE: a down-migration
+    /// routinely drops the columns and tables its up-migration added, which
+    /// destroys every row this app wrote through them. Nothing snapshots
+    /// them first, so there is no undo.
     #[arg(long)]
     allow_downgrade: bool,
     /// Skip the confirmation prompt.
@@ -128,7 +130,7 @@ pub(super) fn run(args: MoveArgs) -> Result<()> {
     let backwards = is_backwards(&install.installed_version, &target);
     if backwards && !args.allow_downgrade {
         return Err(anyhow!(
-            "{} is installed at {} in {}; {} is not newer. Pass --allow-downgrade to move backwards — module migrations are forward-only, so an older version may not understand data the newer one already wrote.",
+            "{} is installed at {} in {}; {} is older. Pass --allow-downgrade to move backwards — it reverts the module's app-scope migrations, and a reverted migration drops what it created, destroying the rows in it. There is no undo.",
             install.slug,
             install.installed_version,
             app.slug,
@@ -152,10 +154,10 @@ pub(super) fn run(args: MoveArgs) -> Result<()> {
         );
         if backwards {
             eprintln!(
-                "{} this is a DOWNGRADE. The module's app migrations only run forward, so {} may not be able to read data {} wrote.",
+                "{} this is a DOWNGRADE. Moving {} → {} reverts the module's app-scope migrations; whatever they created is dropped, and the rows in it are destroyed with no undo.",
                 warn_prefix(),
-                target,
-                install.installed_version
+                install.installed_version,
+                target
             );
         }
         let confirmed = Confirm::with_theme(&ColorfulTheme::default())
@@ -310,8 +312,11 @@ fn version_label(v: &PublishedVersion, installed: &str) -> String {
     label
 }
 
-/// Whether `target` is NOT strictly newer than `installed` — the condition
-/// `--allow-downgrade` exists for. A dev-mount install (no pin) and any
+/// Whether `target` is strictly OLDER than `installed` — the condition
+/// `--allow-downgrade` exists for. Equal is deliberately NOT backwards: the
+/// platform answers an equal target with its own `version_unchanged`, for
+/// which the flag would do nothing, so claiming a downgrade here would
+/// demand a flag that cannot help. A dev-mount install (no pin) and any
 /// version either side can't parse as SemVer are left to the platform,
 /// which is the authority; guessing here would block a legal move.
 fn is_backwards(installed: &str, target: &str) -> bool {
@@ -322,7 +327,7 @@ fn is_backwards(installed: &str, target: &str) -> bool {
         module_meta::parse_semver(installed),
         module_meta::parse_semver(target),
     ) {
-        (Some(from), Some(to)) => to <= from,
+        (Some(from), Some(to)) => to < from,
         _ => false,
     }
 }
@@ -343,21 +348,46 @@ fn held_error(slug: &str, target: &str, blockers: &[api::UpdateBlocker]) -> anyh
 /// `update_held` never reaches here — its 409 carries a blocker list and is
 /// surfaced by [`held_error`] instead.
 ///
-/// `downgrade_not_supported` is the version-skew case: a platform that
-/// predates opt-in downgrades ignores the `allowDowngrade` field (its
-/// decoder drops unknown keys) and still refuses, so a caller who DID pass
-/// the flag is told the server is old rather than being told to pass a flag
-/// they already passed.
+/// Every hint is printed AFTER the platform's own `message`, so a hint may
+/// only add what the CLI knows and the platform does not: which flag to
+/// re-run with, which command lists the alternatives. None of them may
+/// restate WHY the platform refused. That rule is not style — the platform
+/// deliberately sends more than one distinct message under a single code,
+/// and a hint that names one of the causes is wrong for the others:
+///
+/// * `downgrade_not_supported` covers a backward SemVer move AND a target
+///   whose app-migration counter is lower than the install's watermark. The
+///   second reaches a dev-mount install with no pinned version at all, and a
+///   target that is SemVer-*newer*. The old hint here said "the target is not
+///   newer than the installed version", which is a flat contradiction of the
+///   message it was appended to in that case.
+/// * `downgrade_failed` means the module answered the revert with an error,
+///   and the platform quotes that error verbatim precisely because it cannot
+///   classify it (the SDK's downgrade response carries no machine-readable
+///   cause). A CLI sentence guessing at "it publishes no rollback for one of
+///   these migrations" would put back the exact assertion the platform
+///   removed.
+///
+/// The one case that IS the CLI's to explain is version skew: a platform
+/// predating opt-in downgrades drops the unknown `allowDowngrade` key and
+/// refuses anyway, so a caller who already passed the flag is told the
+/// server is old instead of being told to pass a flag they just passed.
 fn move_error_hint(code: &str, allow_downgrade: bool) -> &'static str {
     match code {
         "version_not_found" => {
             " (that version isn't published for this module any more — re-run without --to to list what is)"
         }
+        "version_unchanged" => {
+            " (nothing moved — re-run without --to to list the other published versions)"
+        }
         "downgrade_not_supported" if allow_downgrade => {
-            " (this platform still refuses downgrades outright — it ignored --allow-downgrade. Update the platform, or pick a version newer than the installed one.)"
+            " (this platform refuses backward moves outright — it ignored --allow-downgrade. Update the platform, or pick a version it will accept.)"
         }
         "downgrade_not_supported" => {
-            " (the target is not newer than the installed version — pass --allow-downgrade to move backwards)"
+            " (re-run with --allow-downgrade to accept it — reverting a migration drops what it created and destroys the rows in it, with no undo)"
+        }
+        "downgrade_failed" => {
+            " (the version pin was NOT moved. The platform does not diagnose this — the text it quotes is the module's own report; take it to the module's author, then re-run.)"
         }
         "not_found" => " (no such app, the module isn't installed in it, or you are not a member)",
         "forbidden" => " (moving an install's version needs the app owner or an admin)",
@@ -448,15 +478,17 @@ mod tests {
     }
 
     #[test]
-    fn is_backwards_detects_older_and_equal() {
+    fn is_backwards_detects_older() {
         assert!(is_backwards("0.2.0", "0.1.0"));
-        assert!(is_backwards("0.2.0", "0.2.0"));
         assert!(is_backwards("1.0.0", "1.0.0-beta.1"));
     }
 
     #[test]
     fn is_backwards_false_for_forward_and_dev() {
         assert!(!is_backwards("0.1.0", "0.2.0"));
+        // Equal is version_unchanged on the platform, not a downgrade —
+        // --allow-downgrade would not make it succeed, so don't demand it.
+        assert!(!is_backwards("0.2.0", "0.2.0"));
         // A dev-mount install has no pin to compare against, so any published
         // target is a forward move — the same rule the platform applies.
         assert!(!is_backwards(DEV_INSTALL, "0.1.0"));
@@ -493,7 +525,8 @@ mod tests {
     #[test]
     fn move_error_hint_splits_on_the_downgrade_flag() {
         assert!(
-            move_error_hint("downgrade_not_supported", false).contains("pass --allow-downgrade")
+            move_error_hint("downgrade_not_supported", false)
+                .contains("--allow-downgrade to accept")
         );
         let old_server = move_error_hint("downgrade_not_supported", true);
         assert!(
@@ -502,12 +535,44 @@ mod tests {
         );
     }
 
+    /// `downgrade_not_supported` carries two different platform messages —
+    /// a backward SemVer move, and a target with fewer app migrations than
+    /// the install has applied (which can be SemVer-FORWARD, or hit a
+    /// dev-mount install with no pin at all). The hint may only name the
+    /// remedy both share; asserting the SemVer cause would contradict the
+    /// message it is appended to in the second case.
+    #[test]
+    fn downgrade_hint_names_the_remedy_not_a_cause() {
+        let hint = move_error_hint("downgrade_not_supported", false);
+        assert!(!hint.contains("not newer"), "{hint}");
+        assert!(!hint.contains("older than"), "{hint}");
+        assert!(hint.contains("--allow-downgrade"), "{hint}");
+    }
+
+    /// The platform quotes the module's own error for `downgrade_failed`
+    /// because it cannot classify the cause. The hint must not supply one —
+    /// no talk of missing down-files or unsupported rollbacks.
+    #[test]
+    fn downgrade_failed_hint_defers_to_the_module_report() {
+        let hint = move_error_hint("downgrade_failed", false);
+        assert!(hint.contains("module's own report"), "{hint}");
+        assert!(hint.contains("pin was NOT moved"), "{hint}");
+        assert!(!hint.contains("down.sql"), "{hint}");
+        assert!(!hint.contains("rollback for"), "{hint}");
+        // Same hint whether or not the flag was passed — reaching this code
+        // means the flag WAS accepted and the revert then failed.
+        assert_eq!(hint, move_error_hint("downgrade_failed", true));
+    }
+
     #[test]
     fn move_error_hint_for_other_known_codes() {
         assert!(move_error_hint("version_not_found", false).contains("--to"));
+        assert!(move_error_hint("version_unchanged", false).contains("--to"));
         assert!(move_error_hint("forbidden", false).contains("admin"));
         assert!(move_error_hint("not_found", false).contains("member"));
         assert!(move_error_hint("validation_error", false).contains("SemVer"));
+        assert!(move_error_hint("bad_request", false).contains("SemVer"));
+        assert_eq!(move_error_hint("internal_error", false), "");
         assert_eq!(move_error_hint("something_else", false), "");
     }
 }


### PR DESCRIPTION
## Why

Under per-version module transport an install points at exactly one published version, so rolling a module forward (or back) is a deliberate act on **one app's install**. `POST /v1/apps/{ref}/modules/{id}/update` has existed server-side for a while with **no client at all** — this adds one.

```bash
mirrorstack module move --app my-app --module media             # pick from the published versions
mirrorstack module move --app my-app --module media --to 0.2.0  # …or name it outright
mirrorstack module move --app my-app --module media --to 0.1.0 --allow-downgrade
```

Also reachable as `mirrorstack app module move` (the `module` tree is mounted under `apps` too).

## What

**Version listing reuses an endpoint that already exists** — `GET /v1/modules/{id}/version-history`, the any-authenticated-user sibling of the owner-scoped `/versions`, so an app admin can enumerate the versions of a module somebody else wrote. No new server surface was invented.

- Omitting `--to` prompts over that list on a TTY (newest first, installed one marked) and prints it then stops without one — a non-interactive run does not get to guess a version.
- An explicit `--to` is checked against the list locally, so a typo names the real choices instead of producing a bare 404.
- The install is resolved through `GET /v1/apps/{id}/installs`, not `GET /v1/modules/{slug}` — the latter is owner-scoped and would 404 for an operator moving a module they didn't write. Slug matching refuses ambiguity (two owners can ship the same slug into one app) and asks for the UUID.

**Downgrades are an explicit opt-in.** `--allow-downgrade` is gated client-side *before* the request, so the flag is a real decision rather than one that only matters after the fact. Equal-version is a no-op that prints and exits.

**Error hints** follow `deploy_error_hint`: `version_not_found`, `downgrade_not_supported`, `not_found`, `forbidden`, `validation_error`/`bad_request`. `update_held` (409) is modelled as an *outcome value*, not an `ApiError` — the envelope carries the peer blocker list, which has to survive the trip, and keeping `ApiError` as the error type lets the call sit inside `credentials::with_refresh_retry` unchanged. The blockers are rendered as `oauth-google needs ^0.1, billing needs ~0.1.2`.

## Server version skew — the one thing to check

A concurrent change is adding opt-in downgrade support server-side. This client is written to be correct on **both** sides of that:

- The field is **omitted entirely** when the flag is not passed (`skip_serializing_if`), so a platform that predates it receives byte-for-byte the body it always received.
- When an old platform answers `422 downgrade_not_supported` to a caller who **did** pass `--allow-downgrade`, the hint says *the server is old and ignored the flag* — not "pass `--allow-downgrade`", which would be nonsense advice to someone who just did.

**Coordination point:** the request field is serialized as `allowDowngrade`, chosen to match the install family's existing camelCase request bodies (`moduleId` on install, `routeLocal` on the route-local PATCH). Nothing named `allow_downgrade`/`allowDowngrade` exists in any api-platform branch yet, so if the server-side PR picks the snake_case spelling instead, this one line in `UpdateInstallInput` has to change with it.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` — 321 passing (14 new: 7 api-layer mockito tests covering the wire body in both flag states, the 409 blocker envelope, the 422 code and the 401; 7 command-layer tests covering install resolution, `--to` validation, the downgrade predicate, the blocker message and the hint table).

## Not done

- No `mirrorstack module versions` standalone listing command — listing is folded into `move` where an operator needs it. Say the word if a separate read-only command is wanted.
- Changelogs are not rendered in the picker (the endpoint returns them); the version + publish date is what an operator scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)