### PR TITLE
feat(module): rename a module's slug without minting a new ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ mirrorstack login --no-browser # Sign in on SSH/headless (paste the code shown o
 mirrorstack logout             # Revoke the current session and wipe local credentials
 mirrorstack whoami             # Print the currently signed-in user
 mirrorstack app module init    # Register a new module on the platform
+mirrorstack app module rename  # Safely rename a module slug without changing its ID
 mirrorstack module deploy      # Cross-compile Linux/arm64, package a bootstrap zip, and upload it
 mirrorstack app web deploy     # Deploy a static build directory to app hosting
 mirrorstack module capabilities         # Which host slots exist, who fills them, what is broken

--- a/src/api.rs
+++ b/src/api.rs
@@ -274,6 +274,46 @@ pub fn create_module(
     })
 }
 
+/// POST /v1/modules/{id}/slug — rename a module without changing its platform
+/// identity, installed references, or ID-namespaced tables. `module_id` is the
+/// catalog UUID (`get_module(...).id`), never the sanitized `.env` form.
+///
+/// The endpoint ships in the api-platform slug-rename PR and does not exist on
+/// `main` yet; this one `format!` is the whole contract surface, so a change to
+/// the agreed path or body is a one-line edit here.
+pub fn rename_module_slug(
+    http: &Client,
+    apps_base: &str,
+    access_token: &str,
+    module_id: &str,
+    new_slug: &str,
+) -> Result<Module, ApiError> {
+    #[derive(Serialize)]
+    struct Body<'a> {
+        slug: &'a str,
+    }
+
+    let endpoint = format!(
+        "{}/v1/modules/{module_id}/slug",
+        apps_base.trim_end_matches('/')
+    );
+    let resp = http
+        .post(&endpoint)
+        .bearer_auth(access_token)
+        .header("Accept", "application/json")
+        .json(&Body { slug: new_slug })
+        .send()?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp.json::<Module>()?);
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(ApiError::Unauthenticated);
+    }
+    Err(envelope_error(resp))
+}
+
 #[derive(Debug, Serialize)]
 pub struct RecordModuleVersionInput<'a> {
     /// Canonical SemVer, no `v` prefix (the platform 422s anything else).
@@ -1911,6 +1951,73 @@ mod tests {
         let err =
             get_module(&test_client(), &server.url(), "expired", "forbidden-slug").unwrap_err();
         assert!(matches!(err, ApiError::Unauthenticated), "got {err:?}");
+    }
+
+    #[test]
+    fn rename_module_slug_posts_identity_preserving_request() {
+        let mut server = Server::new();
+        let request = server
+            .mock(
+                "POST",
+                "/v1/modules/01234567-89ab-cdef-0123-456789abcdef/slug",
+            )
+            .match_header("authorization", "Bearer AT")
+            .match_header("accept", "application/json")
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"slug":"identity-core"}"#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "id": "01234567-89ab-cdef-0123-456789abcdef",
+                    "name": "OAuth Core",
+                    "slug": "identity-core",
+                    "owner_id": "u-1"
+                })
+                .to_string(),
+            )
+            .create();
+
+        let module = rename_module_slug(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "01234567-89ab-cdef-0123-456789abcdef",
+            "identity-core",
+        )
+        .unwrap();
+        request.assert();
+        assert_eq!(module.slug, "identity-core");
+        assert_eq!(module.id, "01234567-89ab-cdef-0123-456789abcdef");
+    }
+
+    #[test]
+    fn rename_module_slug_surfaces_slug_taken_envelope() {
+        let mut server = Server::new();
+        let request = server
+            .mock("POST", "/v1/modules/module-id/slug")
+            .with_status(409)
+            .with_body(
+                r#"{"error":{"code":"slug_taken","message":"slug already belongs to a module"}}"#,
+            )
+            .create();
+
+        let error = rename_module_slug(
+            &test_client(),
+            &server.url(),
+            "AT",
+            "module-id",
+            "identity-core",
+        )
+        .unwrap_err();
+        request.assert();
+        match error {
+            ApiError::Server { status, code, .. } => {
+                assert_eq!(status, 409);
+                assert_eq!(code, "slug_taken");
+            }
+            other => panic!("expected Server, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -274,7 +274,7 @@ pub fn create_module(
     })
 }
 
-/// POST /v1/modules/{id}/slug — rename a module without changing its platform
+/// PUT /v1/modules/{id}/slug — rename a module without changing its platform
 /// identity, installed references, or ID-namespaced tables. `module_id` is the
 /// catalog UUID (`get_module(...).id`), never the sanitized `.env` form.
 ///
@@ -298,7 +298,7 @@ pub fn rename_module_slug(
         apps_base.trim_end_matches('/')
     );
     let resp = http
-        .post(&endpoint)
+        .put(&endpoint)
         .bearer_auth(access_token)
         .header("Accept", "application/json")
         .json(&Body { slug: new_slug })
@@ -1954,11 +1954,11 @@ mod tests {
     }
 
     #[test]
-    fn rename_module_slug_posts_identity_preserving_request() {
+    fn rename_module_slug_puts_identity_preserving_request() {
         let mut server = Server::new();
         let request = server
             .mock(
-                "POST",
+                "PUT",
                 "/v1/modules/01234567-89ab-cdef-0123-456789abcdef/slug",
             )
             .match_header("authorization", "Bearer AT")
@@ -1995,7 +1995,7 @@ mod tests {
     fn rename_module_slug_surfaces_slug_taken_envelope() {
         let mut server = Server::new();
         let request = server
-            .mock("POST", "/v1/modules/module-id/slug")
+            .mock("PUT", "/v1/modules/module-id/slug")
             .with_status(409)
             .with_body(
                 r#"{"error":{"code":"slug_taken","message":"slug already belongs to a module"}}"#,

--- a/src/commands/dev/mod.rs
+++ b/src/commands/dev/mod.rs
@@ -210,7 +210,7 @@ fn run_outer(root: &Path, args: &DevArgs) -> Result<()> {
         let reason = if slug.is_empty() {
             "no main.go"
         } else {
-            "no ID — run `mirrorstack app module register`"
+            "no ID — if the slug was renamed, use `mirrorstack app module rename`; register is only for a brand-new module"
         };
         eprintln!(
             "  {} {} ({})",

--- a/src/commands/dev/module_meta.rs
+++ b/src/commands/dev/module_meta.rs
@@ -18,6 +18,7 @@
 //! plain, unsuffixed `os.Getenv("MS_MODULE_ID")`, and `dev/mod.rs` injects a
 //! plain `MS_MODULE_ID=<value>` into just that module's child env.
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -64,12 +65,47 @@ pub(crate) fn read_module_meta(module_dir: &Path, root: &Path) -> Result<ModuleM
 pub(super) fn read_module_id(module_dir: &Path, root: &Path) -> Result<String> {
     let meta = read_module_meta(module_dir, root)?;
     if meta.id.is_empty() {
-        return Err(anyhow!(
-            "dev: module {} has no ID set. Run `mirrorstack app module register` first.",
-            module_dir.display()
-        ));
+        return Err(missing_module_id_error(module_dir, root, &meta.slug));
     }
     Ok(meta.id)
+}
+
+/// Build the deliberately verbose missing-ID failure shared by `dev` and
+/// module-management commands. A slug edit can make the normal lookup miss an
+/// ID that is still present under its old key; putting the recovery before the
+/// registration warning keeps an operator from replacing a live identity.
+pub(crate) fn missing_module_id_error(module_dir: &Path, root: &Path, slug: &str) -> anyhow::Error {
+    let expected_key = env_key_for_slug(slug);
+    let path = env_path(root);
+    let stranded = unclaimed_module_id_keys(root);
+
+    // No `dev:` prefix: `module rename` raises this too, and the message
+    // already names the module dir and the .env it looked in.
+    let mut message = format!(
+        "module {} has no ID set.\nParsed slug: {slug}\nExpected env key: {expected_key}\nWorkspace .env: {}",
+        module_dir.display(),
+        path.display()
+    );
+
+    if stranded.is_empty() {
+        message.push_str("\nNo non-empty unclaimed MS_MODULE_ID_* keys were found in that file.");
+    } else {
+        message.push_str("\n\nPossible IDs stranded by a slug rename:");
+        for (key, _) in &stranded {
+            message.push_str(&format!("\n  - {key}"));
+        }
+        message.push_str(
+            "\nThe module ID is not lost. Use the non-destructive fix first: rename the matching key while keeping the SAME value:",
+        );
+        message.push_str(&format!(
+            "\n  mirrorstack app module rename --from <old-slug> --to {slug} --local-only"
+        ));
+    }
+
+    message.push_str(
+        "\n\nCreating a module here would mint a NEW module ID, create new empty module tables, and leave any existing install pointing at the old ID — there is no undo.\n`mirrorstack app module register` is only correct when this module has never been registered in THIS environment.",
+    );
+    anyhow!(message)
 }
 
 /// Path to the workspace root's `.env` file — holds one `MS_MODULE_ID_<SLUG>`
@@ -104,7 +140,7 @@ pub(crate) fn env_key_for_slug(slug: &str) -> String {
 /// comments, blank lines) is delegated to `dotenvy` — the same crate the
 /// CLI already uses for its own `.env` loading in `main.rs` — instead of a
 /// hand-rolled `KEY=value` scanner.
-fn read_env_module_id(root: &Path, slug: &str) -> String {
+pub(crate) fn read_env_module_id(root: &Path, slug: &str) -> String {
     let key = env_key_for_slug(slug);
     let Ok(iter) = dotenvy::from_path_iter(env_path(root)) else {
         return String::new();
@@ -116,6 +152,36 @@ fn read_env_module_id(root: &Path, slug: &str) -> String {
         }
     }
     String::new()
+}
+
+/// Return non-empty module-ID entries whose slug-derived key is not claimed by
+/// any module currently visible in this workspace. These are usually IDs left
+/// behind by a hand-edited `Config.Slug`, and therefore evidence that minting a
+/// replacement identity would be destructive rather than corrective.
+pub(crate) fn unclaimed_module_id_keys(root: &Path) -> Vec<(String, String)> {
+    let module_dirs = if root.join("go.work").exists() {
+        crate::commands::dev::workspace::discover_modules(root)
+            .map(|modules| modules.into_iter().map(|module| module.abs_dir).collect())
+            .unwrap_or_else(|_| vec![root.to_path_buf()])
+    } else {
+        vec![root.to_path_buf()]
+    };
+
+    let claimed: HashSet<String> = module_dirs
+        .into_iter()
+        .filter_map(|dir| fs::read_to_string(dir.join("main.go")).ok())
+        .filter_map(|body| extract_field(&body, "Slug"))
+        .map(|slug| env_key_for_slug(&slug))
+        .collect();
+
+    let Ok(iter) = dotenvy::from_path_iter(env_path(root)) else {
+        return Vec::new();
+    };
+    iter.filter_map(|item| item.ok())
+        .filter(|(key, value)| {
+            key.starts_with("MS_MODULE_ID_") && !value.is_empty() && !claimed.contains(key)
+        })
+        .collect()
 }
 
 /// Extract the value of a `Field: "..."` pattern from Go source.
@@ -315,6 +381,89 @@ pub(crate) fn promote_version(module_dir: &Path, from: &str, to: &str) -> Result
     let new_body = format!("{}\"{to}\"{}", &body[..abs], &body[abs + needle.len()..]);
     fs::write(&path, new_body).with_context(|| format!("write {}", path.display()))?;
     Ok(())
+}
+
+/// Rename only the quoted `Slug:` literal in `main.go`. The surrounding scan
+/// is intentionally anchored on the field label so comments, migration data,
+/// or other fields that happen to contain the old slug are never rewritten.
+pub(crate) fn rename_slug_in_main_go(module_dir: &Path, from: &str, to: &str) -> Result<()> {
+    let path = module_dir.join("main.go");
+    let body = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let label = body
+        .find("Slug:")
+        .ok_or_else(|| anyhow!("no Slug field in {}", path.display()))?;
+    let after_label = label + "Slug:".len();
+    let open = body[after_label..]
+        .find('"')
+        .map(|offset| after_label + offset)
+        .ok_or_else(|| anyhow!("no quoted Slug literal in {}", path.display()))?;
+    let close = body[open + 1..]
+        .find('"')
+        .map(|offset| open + 1 + offset)
+        .ok_or_else(|| anyhow!("unterminated Slug literal in {}", path.display()))?;
+    let actual = &body[open + 1..close];
+    if actual == to {
+        return Ok(());
+    }
+    if actual != from {
+        return Err(anyhow!(
+            "Slug in {} is {actual:?}, not {from:?} or {to:?}",
+            path.display()
+        ));
+    }
+
+    let new_body = format!("{}{to}{}", &body[..open + 1], &body[close..]);
+    fs::write(&path, new_body).with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+/// Carry a module ID from its old slug-derived `.env` key to the new key.
+/// Only the key bytes on the matching line change: its value, position, line
+/// ending, and every unrelated byte in the file survive the operation.
+pub(crate) fn rename_module_id_key(root: &Path, from_slug: &str, to_slug: &str) -> Result<String> {
+    let old_key = env_key_for_slug(from_slug);
+    let new_key = env_key_for_slug(to_slug);
+    let path = env_path(root);
+    let existing = match fs::read_to_string(&path) {
+        Ok(body) => body,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e).with_context(|| format!("read {}", path.display())),
+    };
+
+    let find_entry = |wanted: &str| -> Option<(usize, String)> {
+        let prefix = format!("{wanted}=");
+        let mut offset = 0usize;
+        for line in existing.split_inclusive('\n') {
+            let content = line.strip_suffix('\n').unwrap_or(line);
+            let content = content.strip_suffix('\r').unwrap_or(content);
+            let trimmed = content.trim_start();
+            if let Some(value) = trimmed.strip_prefix(&prefix) {
+                return Some((offset + content.len() - trimmed.len(), value.to_string()));
+            }
+            offset += line.len();
+        }
+        None
+    };
+
+    let old = find_entry(&old_key);
+    let new = find_entry(&new_key);
+    match (old, new) {
+        (Some(_), Some(_)) => Err(anyhow!(
+            "both {old_key} and {new_key} exist in {}; refusing an ambiguous module ID rename",
+            path.display()
+        )),
+        (None, Some((_, value))) => Ok(value),
+        (Some((key_offset, value)), None) => {
+            let mut new_body = existing;
+            new_body.replace_range(key_offset..key_offset + old_key.len(), &new_key);
+            fs::write(&path, new_body).with_context(|| format!("write {}", path.display()))?;
+            Ok(value)
+        }
+        (None, None) => Err(anyhow!(
+            "neither {old_key} nor {new_key} exists in {}",
+            path.display()
+        )),
+    }
 }
 
 /// Write `MS_MODULE_ID_<SLUG>=<new_id>` into `<root>/.env`, creating the
@@ -611,6 +760,144 @@ func main() {
             .unwrap_err()
             .to_string();
         assert!(err.contains("v2.0.0-dev"), "got {err}");
+    }
+
+    #[test]
+    fn rename_slug_rewrites_only_slug_literal_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = r#"package main
+
+// oauth-core remains documentation for the former name.
+var legacy = "oauth-core"
+
+func main() {
+    ms.Init(ms.Config{
+        Slug: "oauth-core",
+        Name: "oauth-core",
+    })
+}
+"#;
+        std::fs::write(tmp.path().join("main.go"), source).unwrap();
+
+        rename_slug_in_main_go(tmp.path(), "oauth-core", "identity-core").unwrap();
+        rename_slug_in_main_go(tmp.path(), "oauth-core", "identity-core").unwrap();
+
+        let rewritten = std::fs::read_to_string(tmp.path().join("main.go")).unwrap();
+        assert!(rewritten.contains("Slug: \"identity-core\""));
+        assert!(rewritten.contains("// oauth-core remains"));
+        assert!(rewritten.contains("var legacy = \"oauth-core\""));
+        assert!(rewritten.contains("Name: \"oauth-core\""));
+    }
+
+    #[test]
+    fn rename_module_id_key_preserves_value_position_and_unrelated_lines() {
+        let tmp = tempfile::tempdir().unwrap();
+        let before = "# module ids\nMS_MODULE_ID_OTHER=mother\n\nMS_MODULE_ID_OAUTH_CORE=m0123ABCxyz\nUNRELATED=keep me\n";
+        std::fs::write(tmp.path().join(".env"), before).unwrap();
+
+        let carried = rename_module_id_key(tmp.path(), "oauth-core", "identity-core").unwrap();
+        assert_eq!(carried, "m0123ABCxyz");
+        let after = std::fs::read_to_string(tmp.path().join(".env")).unwrap();
+        assert_eq!(
+            after,
+            "# module ids\nMS_MODULE_ID_OTHER=mother\n\nMS_MODULE_ID_IDENTITY_CORE=m0123ABCxyz\nUNRELATED=keep me\n"
+        );
+    }
+
+    #[test]
+    fn rename_module_id_key_is_idempotent_when_new_key_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = "MS_MODULE_ID_IDENTITY_CORE=msameid\nOTHER=unchanged\n";
+        std::fs::write(tmp.path().join(".env"), body).unwrap();
+        assert_eq!(
+            rename_module_id_key(tmp.path(), "oauth-core", "identity-core").unwrap(),
+            "msameid"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join(".env")).unwrap(),
+            body
+        );
+    }
+
+    #[test]
+    fn rename_module_id_key_refuses_both_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".env"),
+            "MS_MODULE_ID_OAUTH_CORE=mold\nMS_MODULE_ID_IDENTITY_CORE=mnew\n",
+        )
+        .unwrap();
+        let error = rename_module_id_key(tmp.path(), "oauth-core", "identity-core")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("MS_MODULE_ID_OAUTH_CORE"), "{error}");
+        assert!(error.contains("MS_MODULE_ID_IDENTITY_CORE"), "{error}");
+    }
+
+    #[test]
+    fn rename_module_id_key_refuses_when_neither_key_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".env"), "OTHER=keep\n").unwrap();
+        let error = rename_module_id_key(tmp.path(), "oauth-core", "identity-core")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("MS_MODULE_ID_OAUTH_CORE"), "{error}");
+        assert!(error.contains("MS_MODULE_ID_IDENTITY_CORE"), "{error}");
+    }
+
+    #[test]
+    fn unclaimed_keys_find_stranded_slug_but_not_workspace_module() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("go.work"),
+            "go 1.26\nuse (\n  ./identity-core\n  ./media\n)\n",
+        )
+        .unwrap();
+        for (dir, slug) in [("identity-core", "identity-core"), ("media", "media")] {
+            let module = tmp.path().join(dir);
+            std::fs::create_dir(&module).unwrap();
+            std::fs::write(
+                module.join("main.go"),
+                format!("package main\nvar config = Config{{Slug: \"{slug}\"}}\n"),
+            )
+            .unwrap();
+        }
+        std::fs::write(
+            tmp.path().join(".env"),
+            "MS_MODULE_ID_OAUTH_CORE=mstranded\nMS_MODULE_ID_MEDIA=mclaimed\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            unclaimed_module_id_keys(tmp.path()),
+            vec![(
+                "MS_MODULE_ID_OAUTH_CORE".to_string(),
+                "mstranded".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn missing_id_error_leads_to_rename_for_stranded_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("main.go"),
+            "package main\nvar config = Config{Slug: \"identity-core\"}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join(".env"),
+            "MS_MODULE_ID_OAUTH_CORE=mstranded\n",
+        )
+        .unwrap();
+
+        let error = missing_module_id_error(tmp.path(), tmp.path(), "identity-core").to_string();
+        assert!(
+            !error.contains("Run `mirrorstack app module register` first"),
+            "{error}"
+        );
+        assert!(error.contains("MS_MODULE_ID_OAUTH_CORE"), "{error}");
+        assert!(error.contains("rename"), "{error}");
     }
 
     #[test]

--- a/src/commands/module/mod.rs
+++ b/src/commands/module/mod.rs
@@ -25,6 +25,7 @@ mod artifact;
 pub(crate) mod capabilities;
 mod changelog;
 mod readme;
+mod rename;
 mod scaffold;
 mod version_move;
 
@@ -52,6 +53,9 @@ enum ModuleCommand {
     /// key in the workspace root's .env, creates them via the API, and
     /// writes the assigned ID back under that module's key in .env.
     Register(RegisterArgs),
+    /// Rename a module slug while preserving its platform ID, installs, and
+    /// tables. This is the safe alternative to re-registering after a rename.
+    Rename(rename::RenameArgs),
     /// Deploy the version your code declares (the newest Config.Versions
     /// key in ./main.go). Cross-compiles the module for Linux/arm64 and
     /// packages it as a Lambda `bootstrap` zip, records the version with its
@@ -101,6 +105,11 @@ pub struct RegisterArgs {
     /// Skip confirmation prompts.
     #[arg(long, short)]
     yes: bool,
+    /// Create a new module even when the workspace `.env` holds module IDs
+    /// that match no module here — only correct when this really is a
+    /// brand-new module.
+    #[arg(long)]
+    allow_new: bool,
 }
 
 #[derive(Args)]
@@ -126,6 +135,7 @@ pub fn run(args: ModuleArgs) -> Result<()> {
         ModuleCommand::Capabilities(c) => capabilities::run(c),
         ModuleCommand::Init(i) => init(i),
         ModuleCommand::Register(r) => register(r),
+        ModuleCommand::Rename(r) => rename::run(r),
         ModuleCommand::Deploy(d) => deploy(d),
         ModuleCommand::Move(m) => version_move::run(m),
     }
@@ -303,10 +313,16 @@ fn register(args: RegisterArgs) -> Result<()> {
     if module_dirs.is_empty() {
         return Err(anyhow!("go.work has no `use` directives"));
     }
+    // Compute this once against the pre-command workspace. If one old key is
+    // stranded, every would-be create deserves the same conservative guard;
+    // mutating the set as this loop progresses could make later modules look
+    // safer merely because an earlier module was registered.
+    let unclaimed_ids = module_meta::unclaimed_module_id_keys(&cwd);
 
     let theme = ColorfulTheme::default();
     let mut registered = 0u32;
     let mut skipped = 0u32;
+    let mut refused_new = 0u32;
 
     for rel_dir in &module_dirs {
         let abs_dir = cwd.join(rel_dir);
@@ -339,7 +355,32 @@ fn register(args: RegisterArgs) -> Result<()> {
             continue;
         }
 
-        if !args.yes {
+        let mut dangerous_create_confirmed = false;
+        if !unclaimed_ids.is_empty() && !args.allow_new {
+            print_stranded_id_register_guard(&meta.slug, &unclaimed_ids);
+            if args.yes {
+                refused_new += 1;
+                continue;
+            }
+            dangerous_create_confirmed = Confirm::with_theme(&theme)
+                .with_prompt(format!(
+                    "Create a NEW ID for {} despite the stranded workspace IDs?",
+                    meta.slug
+                ))
+                .default(false)
+                .interact()?;
+            if !dangerous_create_confirmed {
+                eprintln!(
+                    "{} skipped {}. Use `mirrorstack app module rename --from <old-slug> --to {}` to preserve the existing ID.",
+                    warn_prefix(),
+                    meta.slug,
+                    meta.slug
+                );
+                continue;
+            }
+        }
+
+        if !args.yes && !dangerous_create_confirmed {
             eprintln!();
             eprintln!("  {} {}", style("Module:").dim(), style(&meta.name).bold());
             eprintln!(
@@ -437,7 +478,30 @@ fn register(args: RegisterArgs) -> Result<()> {
         registered,
         skipped
     );
+    if refused_new > 0 {
+        return Err(anyhow!(
+            "refused to create {refused_new} new module ID(s) while the workspace has unclaimed IDs; use `module rename`, or pass --allow-new only for genuinely brand-new modules"
+        ));
+    }
     Ok(())
+}
+
+fn print_stranded_id_register_guard(slug: &str, unclaimed: &[(String, String)]) {
+    eprintln!();
+    eprintln!(
+        "{} module '{}' has no ID under its current slug, but the workspace .env contains unclaimed module-ID keys:",
+        warn_prefix(),
+        slug
+    );
+    for (key, _) in unclaimed {
+        eprintln!("  - {key}");
+    }
+    eprintln!(
+        "  This looks like a slug rename. `module register` would mint a NEW ID, create new empty module tables, and leave an existing install pointing at the old ID."
+    );
+    eprintln!(
+        "  Preserve the ID with `mirrorstack app module rename --from <old-slug> --to {slug}`. Use --allow-new only when this really is a brand-new module."
+    );
 }
 
 fn deploy(args: DeployArgs) -> Result<()> {
@@ -848,7 +912,7 @@ fn get_owned_module(
     match api::get_module(client, apps_base, access_token, slug) {
         Ok(Some(m)) => Ok(m),
         Ok(None) => Err(anyhow!(
-            "module '{slug}' not found on the platform (run `mirrorstack app module register` first)"
+            "module '{slug}' not found on the platform. The platform may still hold the OLD slug; use `mirrorstack app module rename --from <old-slug> --to {slug}`. `register` mints a new ID and orphans the existing install, so it is only correct if the module was never created."
         )),
         Err(ApiError::Unauthenticated) => Err(session_expired()),
         Err(e) => Err(e.into()),

--- a/src/commands/module/rename.rs
+++ b/src/commands/module/rename.rs
@@ -1,0 +1,440 @@
+//! Safe, identity-preserving module slug rename.
+//!
+//! A module ID is the durable identity behind installs and module-table
+//! namespaces; the slug is only its mutable name. This command keeps those two
+//! concepts separate and makes each remote/local leg independently re-runnable
+//! so an interrupted rename can be completed without minting a replacement ID.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use clap::Args;
+use console::style;
+use dialoguer::{Confirm, theme::ColorfulTheme};
+
+use crate::api::{self, ApiError};
+use crate::commands::dev::module_meta;
+use crate::commands::{
+    DEFAULT_APPS_API_BASE, ENV_APPS_API_URL, ok_mark, resolve_base, session_expired, warn_prefix,
+};
+use crate::{credentials, http};
+
+use super::{sanitize_module_id, slug_valid};
+
+#[derive(Args)]
+pub struct RenameArgs {
+    /// New module slug.
+    #[arg(long)]
+    to: String,
+    /// Previous slug. Defaults to Config.Slug in main.go; pass it explicitly
+    /// when main.go was already edited but the workspace .env was not.
+    #[arg(long)]
+    from: Option<String>,
+    /// Module directory containing main.go. Defaults to cwd.
+    #[arg(long)]
+    dir: Option<PathBuf>,
+    /// Update main.go and the workspace .env without calling the platform.
+    #[arg(long)]
+    local_only: bool,
+    /// Skip the confirmation prompt.
+    #[arg(long, short)]
+    yes: bool,
+}
+
+#[derive(Debug)]
+enum PlatformStep {
+    LocalOnly,
+    AlreadyRenamed,
+    Rename { module_id: String },
+}
+
+pub(crate) fn run(args: RenameArgs) -> Result<()> {
+    let cwd = std::env::current_dir().context("read cwd")?;
+    let module_dir = match args.dir {
+        Some(dir) if dir.is_absolute() => dir,
+        Some(dir) => cwd.join(dir),
+        None => cwd,
+    };
+    let root = workspace_root(&module_dir);
+    let meta = module_meta::read_module_meta(&module_dir, &root).map_err(|e| {
+        anyhow!(
+            "couldn't read the module from {}: {e}. Run from the module directory, or pass --dir <path>.",
+            module_dir.display()
+        )
+    })?;
+    let from = args.from.as_deref().unwrap_or(&meta.slug);
+    validate_rename(from, &args.to)?;
+    if meta.slug != from && meta.slug != args.to {
+        return Err(anyhow!(
+            "Slug in {}/main.go is {:?}, not {:?} or {:?}",
+            module_dir.display(),
+            meta.slug,
+            from,
+            args.to
+        ));
+    }
+
+    let old_key = module_meta::env_key_for_slug(from);
+    let new_key = module_meta::env_key_for_slug(&args.to);
+    let old_id = module_meta::read_env_module_id(&root, from);
+    let new_id = module_meta::read_env_module_id(&root, &args.to);
+    let (carried_id, env_already_renamed) = match (old_id.is_empty(), new_id.is_empty()) {
+        (false, true) => (old_id, false),
+        (true, false) => (new_id, true),
+        (false, false) => {
+            return Err(anyhow!(
+                "both {old_key} and {new_key} exist in {}; refusing an ambiguous module ID rename",
+                root.join(".env").display()
+            ));
+        }
+        (true, true) => {
+            return Err(module_meta::missing_module_id_error(
+                &module_dir,
+                &root,
+                &meta.slug,
+            ));
+        }
+    };
+
+    let mut creds = None;
+    let platform_step = if args.local_only {
+        PlatformStep::LocalOnly
+    } else {
+        let mut loaded = credentials::load_or_login_hint()?;
+        let apps_base = resolve_base(ENV_APPS_API_URL, DEFAULT_APPS_API_BASE);
+        let client = http::client(Duration::from_secs(15))?;
+        let step = resolve_platform_step(
+            &client,
+            &apps_base,
+            &mut loaded,
+            from,
+            &args.to,
+            &carried_id,
+        )?;
+        creds = Some((loaded, apps_base, client));
+        step
+    };
+
+    let main_already_renamed = meta.slug == args.to;
+    if !args.yes {
+        print_plan(
+            from,
+            &args.to,
+            &carried_id,
+            &platform_step,
+            main_already_renamed,
+            env_already_renamed,
+        );
+        let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Rename this module slug while keeping its existing ID?")
+            .default(true)
+            .interact()?;
+        if !confirmed {
+            eprintln!("{}", style("aborted.").yellow());
+            return Ok(());
+        }
+    }
+
+    // The platform half needs network and auth and is the step most likely to
+    // fail for external reasons, so it goes first. The main.go and .env edits
+    // are pure local rewrites and idempotent; if either fails, the exact
+    // --local-only re-run below safely completes the partial operation.
+    match &platform_step {
+        PlatformStep::LocalOnly => {
+            eprintln!("{} platform rename skipped (--local-only)", ok_mark());
+        }
+        PlatformStep::AlreadyRenamed => {
+            eprintln!("{} platform catalog already uses {}", ok_mark(), args.to);
+        }
+        PlatformStep::Rename { module_id } => {
+            let (loaded, apps_base, client) = creds.as_mut().ok_or_else(|| {
+                anyhow!("internal error: missing credentials for platform rename")
+            })?;
+            let renamed = credentials::with_refresh_retry(loaded, |token| {
+                api::rename_module_slug(client, apps_base, token, module_id, &args.to)
+            });
+            match renamed {
+                Ok(module) => eprintln!(
+                    "{} platform catalog renamed {} → {} ({})",
+                    ok_mark(),
+                    from,
+                    style(&module.slug).cyan().bold(),
+                    style(&carried_id).dim()
+                ),
+                Err(ApiError::Unauthenticated) => return Err(session_expired()),
+                Err(ApiError::Server { code, message, .. }) => {
+                    return Err(anyhow!("{code}: {message}"));
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+
+    let rerun = rerun_command(from, &args.to, &module_dir);
+    if main_already_renamed {
+        eprintln!("{} main.go already uses Slug: {:?}", ok_mark(), args.to);
+    } else if let Err(e) = module_meta::rename_slug_in_main_go(&module_dir, from, &args.to) {
+        return Err(local_failure("update main.go", e, &rerun));
+    } else {
+        eprintln!(
+            "{} updated Slug in {}/main.go",
+            ok_mark(),
+            module_dir.display()
+        );
+    }
+
+    if env_already_renamed {
+        eprintln!(
+            "{} {} already carries {}",
+            ok_mark(),
+            new_key,
+            style(&carried_id).dim()
+        );
+    } else {
+        match module_meta::rename_module_id_key(&root, from, &args.to) {
+            Ok(id) => eprintln!(
+                "{} renamed {} → {} in {} (same ID: {})",
+                ok_mark(),
+                old_key,
+                new_key,
+                root.join(".env").display(),
+                style(id).dim()
+            ),
+            Err(e) => return Err(local_failure("update the workspace .env", e, &rerun)),
+        }
+    }
+
+    print_untouched_tail(&module_dir, from, &args.to);
+    Ok(())
+}
+
+fn validate_rename(from: &str, to: &str) -> Result<()> {
+    if !slug_valid(to) {
+        return Err(anyhow!(
+            "slug '{to}' is invalid: must be 3-40 chars, start with a letter, end with a letter or digit, lowercase + hyphen only."
+        ));
+    }
+    if to == from {
+        return Err(anyhow!("new slug '{to}' is the same as the old slug"));
+    }
+    Ok(())
+}
+
+/// Find the nearest `go.work` at or above the module directory. A module with
+/// no workspace ancestor owns its own `.env`, matching deploy's standalone
+/// metadata rule.
+fn workspace_root(module_dir: &Path) -> PathBuf {
+    module_dir
+        .ancestors()
+        .find(|dir| dir.join("go.work").is_file())
+        .unwrap_or(module_dir)
+        .to_path_buf()
+}
+
+fn resolve_platform_step(
+    client: &reqwest::blocking::Client,
+    apps_base: &str,
+    creds: &mut credentials::Credentials,
+    from: &str,
+    to: &str,
+    carried_id: &str,
+) -> Result<PlatformStep> {
+    let target = credentials::with_refresh_retry(creds, |token| {
+        api::get_module(client, apps_base, token, to)
+    });
+    let target = map_api_result(target)?;
+    if target
+        .as_ref()
+        .is_some_and(|module| sanitize_module_id(&module.id) == carried_id)
+    {
+        return Ok(PlatformStep::AlreadyRenamed);
+    }
+
+    let source = credentials::with_refresh_retry(creds, |token| {
+        api::get_module(client, apps_base, token, from)
+    });
+    let Some(source) = map_api_result(source)? else {
+        return Err(anyhow!(
+            "module '{from}' was not found in the caller's platform catalog, so ownership of ID {carried_id} cannot be proved; no changes were made"
+        ));
+    };
+    let platform_id = sanitize_module_id(&source.id);
+    if platform_id != carried_id {
+        return Err(anyhow!(
+            "workspace ID mismatch: {old_key} carries {carried_id}, but platform module '{from}' has {platform_id}; refusing to compound a mis-wired workspace",
+            old_key = module_meta::env_key_for_slug(from)
+        ));
+    }
+    Ok(PlatformStep::Rename {
+        module_id: source.id,
+    })
+}
+
+fn map_api_result<T>(result: Result<T, ApiError>) -> Result<T> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(ApiError::Unauthenticated) => Err(session_expired()),
+        Err(ApiError::Server { code, message, .. }) => Err(anyhow!("{code}: {message}")),
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn print_plan(
+    from: &str,
+    to: &str,
+    carried_id: &str,
+    platform: &PlatformStep,
+    main_already: bool,
+    env_already: bool,
+) {
+    let platform = match platform {
+        PlatformStep::LocalOnly => "skip (--local-only)",
+        PlatformStep::AlreadyRenamed => "skip (already renamed)",
+        PlatformStep::Rename { .. } => "rename catalog slug",
+    };
+    eprintln!();
+    eprintln!(
+        "  {} {} → {}",
+        style("Slug:").dim(),
+        style(from).bold(),
+        style(to).cyan().bold()
+    );
+    eprintln!("  {}   {}", style("ID:").dim(), style(carried_id).bold());
+    eprintln!("  {} {platform}", style("Platform:").dim());
+    eprintln!(
+        "  {} {}",
+        style("main.go:").dim(),
+        if main_already {
+            "skip (already renamed)"
+        } else {
+            "rewrite Slug literal"
+        }
+    );
+    eprintln!(
+        "  {}     {}",
+        style(".env:").dim(),
+        if env_already {
+            "skip (key already renamed)"
+        } else {
+            "rename key, preserve value"
+        }
+    );
+}
+
+fn rerun_command(from: &str, to: &str, module_dir: &Path) -> String {
+    format!(
+        "mirrorstack app module rename --from {from} --to {to} --dir {} --local-only --yes",
+        shell_quote(&module_dir.to_string_lossy())
+    )
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+/// A local leg failed after the remote leg was done (or deliberately skipped),
+/// so the tree is half-renamed. Every step is idempotent, so the fix is always
+/// the same `--local-only` re-run rather than any hand repair — and above all
+/// never `register`, which is what a half-renamed tree otherwise invites.
+fn local_failure(action: &str, error: anyhow::Error, rerun: &str) -> anyhow::Error {
+    eprintln!(
+        "{} the platform slug is settled, but the CLI could not {action}, so this tree is half-renamed.",
+        warn_prefix()
+    );
+    eprintln!("  Fix the cause, then re-run exactly: `{rerun}`");
+    eprintln!("  The module ID is unchanged. Do NOT run `mirrorstack app module register`.");
+    error.context(action.to_string())
+}
+
+fn print_untouched_tail(module_dir: &Path, from: &str, to: &str) {
+    eprintln!();
+    eprintln!("What this command did NOT do:");
+    if let Some((actual, expected)) = mismatched_web_package_name(module_dir, to) {
+        eprintln!(
+            "  - {}/web/package.json still names the package {:?}; set `name` to {:?} so build-css.mjs derives CSS scope {:?}.",
+            module_dir.display(),
+            actual,
+            expected,
+            to
+        );
+    }
+    eprintln!(
+        "  - Other modules that contribute into {to} name it by slug; update and re-register them or the contribution is silently dropped at install time."
+    );
+    eprintln!(
+        "  - The module directory and its go.work entry are untouched by design; local dev routes by directory name, so nothing local breaks."
+    );
+    eprintln!("  - Old /settings/module/{from} URLs will no longer resolve.");
+}
+
+fn mismatched_web_package_name(module_dir: &Path, to: &str) -> Option<(String, String)> {
+    let path = module_dir.join("web/package.json");
+    if !path.is_file() {
+        return None;
+    }
+    let body = fs::read_to_string(path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&body).ok()?;
+    let name = json.get("name")?.as_str()?;
+    let (scope, package) = if let Some(scoped) = name.strip_prefix('@') {
+        let (scope, package) = scoped.split_once('/')?;
+        (Some(format!("@{scope}/")), package)
+    } else {
+        (None, name)
+    };
+    let has_web_suffix = package.ends_with("-web");
+    let derived = package.strip_suffix("-web").unwrap_or(package);
+    if derived == to {
+        return None;
+    }
+    let expected_package = if has_web_suffix {
+        format!("{to}-web")
+    } else {
+        to.to_string()
+    };
+    let expected = format!("{}{expected_package}", scope.unwrap_or_default());
+    Some((name.to_string(), expected))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_root_uses_nearest_go_work_ancestor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("workspace");
+        let module = root.join("modules/media");
+        fs::create_dir_all(&module).unwrap();
+        fs::write(root.join("go.work"), "go 1.26\n").unwrap();
+        assert_eq!(workspace_root(&module), root);
+    }
+
+    #[test]
+    fn workspace_root_falls_back_to_standalone_module() {
+        let tmp = tempfile::tempdir().unwrap();
+        let module = tmp.path().join("media");
+        fs::create_dir(&module).unwrap();
+        assert_eq!(workspace_root(&module), module);
+    }
+
+    #[test]
+    fn same_from_and_to_is_rejected() {
+        let error = validate_rename("oauth-core", "oauth-core")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("same as the old slug"), "{error}");
+    }
+
+    #[test]
+    fn invalid_to_is_rejected_with_deploy_wording() {
+        let error = validate_rename("oauth-core", "OAuth_Core")
+            .unwrap_err()
+            .to_string();
+        assert_eq!(
+            error,
+            "slug 'OAuth_Core' is invalid: must be 3-40 chars, start with a letter, end with a letter or digit, lowercase + hyphen only."
+        );
+    }
+}


### PR DESCRIPTION
## The footgun

A module's platform ID lives in the workspace-root `.env` under a slug-derived key —
`env_key_for_slug(slug)` = `MS_MODULE_ID_` + SCREAMING_SNAKE(slug). Rename the slug and
the key stops matching, `read_env_module_id` returns empty, and the CLI aborted with:

```
dev: module <dir> has no ID set. Run `mirrorstack app module register` first.
```

Following that advice runs `create_module`, which mints a **new module UUID**. Installs
are keyed by module UUID and module tables are namespaced by the ID token, so the app's
install keeps pointing at the old ID while the new one gets empty tables. For `oauth-core`
— which hosts the `auth-provider` slot `oauth-google` contributes "Sign in with Google"
into — that is a sign-in outage, and there is no undo.

The ID was never lost. It was sitting in `.env` under the old slug's key the whole time.

## What this does

**1. The missing-ID error no longer leads anywhere destructive.**

```
error: module …/ws2/oauth-core has no ID set.
Parsed slug: identity-core
Expected env key: MS_MODULE_ID_IDENTITY_CORE
Workspace .env: …/ws2/.env

Possible IDs stranded by a slug rename:
  - MS_MODULE_ID_OAUTH_CORE
The module ID is not lost. Use the non-destructive fix first: rename the matching key while keeping the SAME value:
  mirrorstack app module rename --from <old-slug> --to identity-core --local-only

Creating a module here would mint a NEW module ID, create new empty module tables, and leave any existing install pointing at the old ID — there is no undo.
`mirrorstack app module register` is only correct when this module has never been registered in THIS environment.
```

It names the stranded keys it actually found, gives the non-destructive fix **first**, and
states what `register` costs before naming it at all.

**2. `mirrorstack app module rename --to <new-slug>`** — renames the catalog slug through
the platform, rewrites the `Slug:` literal in `main.go`, and carries the ID to the new
`.env` key **in place**, value byte-for-byte unchanged.

All three legs are independently skipped when already done, so an interrupted rename is
completed by re-running the same command. `--local-only` finishes a tree whose catalog is
already renamed (another machine, another developer, a previous partial run); `--from`
recovers a tree whose `main.go` was hand-edited before the CLI existed. The remote leg
runs first — it is the one that fails for external reasons — and a failure in either local
leg prints the exact `--local-only` re-run instead of leaving the operator to improvise.

On success it prints what it deliberately did **not** touch, each one a real way a rename
breaks something silently:

```
What this command did NOT do:
  - …/oauth-core/web/package.json still names the package "@mirrorstack-ai/oauth-core-web"; set `name` to "@mirrorstack-ai/identity-core-web" so build-css.mjs derives CSS scope "identity-core".
  - Other modules that contribute into identity-core name it by slug; update and re-register them or the contribution is silently dropped at install time.
  - The module directory and its go.work entry are untouched by design; local dev routes by directory name, so nothing local breaks.
  - Old /settings/module/oauth-core URLs will no longer resolve.
```

**3. `module register` will not mint over a stranded ID.** When the workspace `.env` holds
`MS_MODULE_ID_*` keys matching no module here, creating a module is treated as the
dangerous act it is: default-deny confirmation interactively, hard refusal under `--yes`
unless the new `--allow-new` is passed. The guard fires **only** in that configuration — a
workspace with no stranded keys behaves exactly as before (verified below).

**4. Two other `register` recommendations softened** — `deploy`'s "not found on the
platform" (a module renamed in code but not in the catalog lands there) and `dev`'s
per-module skip line.

## On the "carry it over automatically" fallback — deliberately not done

The brief floated auto-adopting `MS_MODULE_ID_<OLD_SLUG>` when `<NEW_SLUG>`'s key is
missing. I did not, and the reasoning is the same one that makes this bug bad: **the CLI
cannot know the old slug.** After the rename, `main.go` holds only the new one. The only
signal available is "some key in `.env` matches no module here" — and in a monorepo that
set can have more than one member. Guessing wrong assigns one module *another module's*
UUID, which is the same outage with a different blast radius and no error message at all.

So: **diagnose everywhere, act only under an explicit command.** The stranded keys are
named in the error (and in the `register` guard), and adopting one is an explicit act
where the operator supplies both slugs — `rename --from <old> --to <new> --local-only`.
Same dead end removed, no unrecoverable guess.

## Dependency

Depends on **mirrorstack-ai/api-platform#461** (`feat(modules): make a module slug
renameable with durable former-slug aliases`). Not on `main` yet — merge that first.

`api::rename_module_slug` calls `PUT /v1/modules/{id}/slug` with `{"slug": "<new-slug>"}`,
returning the module object and the standard error envelope. Verified line-by-line against
#461 rather than against the brief:

| Contract | api-platform#461 | this PR |
|---|---|---|
| Method | `r.Put("/{id}/slug", …)` | `PUT` |
| Path | `/v1/modules/{id}/slug` | same |
| Body | `{"slug": "..."}` | same |
| Success | `200` + module object | deserialized as `Module` |
| Errors | `slug_invalid` 422 · `slug_reserved` 400 · `slug_taken` 409 · `not_found` 404 | passed through the shared envelope verbatim |

**This originally sent `POST` and was wrong.** #461 registers the route with `r.Put`, and
chi answers a POST with `405 Method Not Allowed` — so `rename` would have failed against
the real endpoint the moment it shipped, half-renaming the tree at exactly the moment an
operator is most tempted to reach for `register`. Fixed in 64d0e84; the mockito tests now
mock `PUT`, and their `request.assert()` is what proves the verb, since a method mismatch
leaves the mock unhit.

Everything except the default `rename` path works before #461 lands — items 1, 3, 4 and
`rename --local-only` need no server change.

One behaviour inherited from #461 worth knowing: it keeps durable slug history, and its
`slug_taken` covers *previously used* slugs. Renaming back to an old slug is therefore
rejected by the platform, not by the CLI; the message is surfaced verbatim.

Slug renames also require the platform to requalify persisted slug-qualified permission
names (`role_permissions` / `member_permissions`) — that is api-platform#462, not the CLI's.

## Verification — run locally, not in the Codex sandbox

`cargo fmt --all -- --check`, `RUSTFLAGS="-D warnings" cargo clippy --all-targets --all-features`
— both clean.

```
$ cargo test --all-features --no-fail-fast
test result: ok. 376 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

The two mockito tests for `rename_module_slug` are included in that count — worth stating
because a sandboxed run cannot bind sockets and silently skips all 101 socket-backed tests.

End-to-end against a synthetic workspace with the real binary:

```
$ mirrorstack app module rename --to identity-core --local-only --yes
✓ platform rename skipped (--local-only)
✓ updated Slug in …/ws/oauth-core/main.go
✓ renamed MS_MODULE_ID_OAUTH_CORE → MS_MODULE_ID_IDENTITY_CORE in …/ws/.env (same ID: m0fe1c2d34b5a6789abcdef0123456789)

# .env before                                          # .env after
# module ids                                           # module ids
MS_MODULE_ID_OAUTH_CORE=m0fe1c2d34b…6789               MS_MODULE_ID_IDENTITY_CORE=m0fe1c2d34b…6789
MS_MODULE_ID_USERS_ROLES=mfeedface…6677                MS_MODULE_ID_USERS_ROLES=mfeedface…6677
SOME_OTHER_VAR=keep-me                                 SOME_OTHER_VAR=keep-me
```

ID preserved, the other module's key and the unrelated var untouched, and a `main.go`
comment containing the old slug left alone (only the `Slug:` literal moved).

`register` guard, refusing before any POST:

```
$ mirrorstack app module register --yes          # stranded MS_MODULE_ID_OAUTH_CORE present
warning: module 'identity-core' has no ID under its current slug, but the workspace .env contains unclaimed module-ID keys:
  - MS_MODULE_ID_OAUTH_CORE
  This looks like a slug rename. `module register` would mint a NEW ID, create new empty module tables, and leave an existing install pointing at the old ID.
  Preserve the ID with `mirrorstack app module rename --from <old-slug> --to identity-core`. Use --allow-new only when this really is a brand-new module.
✓ done: 0 registered, 0 already had IDs
error: refused to create 1 new module ID(s) while the workspace has unclaimed IDs; use `module rename`, or pass --allow-new only for genuinely brand-new modules
```

Clean-workspace regression — guard silent, behaviour unchanged:

```
$ mirrorstack app module register --yes          # no stranded keys
✓ @i-am-nothing/media already registered (mabc1234567890abcdef1234567890ab)
✓ done: 0 registered, 1 already had IDs
```

No new dependencies. `.github/workflows/` untouched — the release build matrix stays
ubuntu/macos/windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
